### PR TITLE
Fix for Child indexes not being removable

### DIFF
--- a/backend/src/org/commcare/xml/CaseXmlParser.java
+++ b/backend/src/org/commcare/xml/CaseXmlParser.java
@@ -167,12 +167,21 @@ public class CaseXmlParser extends TransactionParser<Case> {
                     String indexName = parser.getName();
                     String caseType = parser.getAttributeValue(null, "case_type");
                     String value = parser.nextText().trim();
+                    
+                    //Remove any ambiguity associated with empty values
+                    if(value == "") { 
+                        value = null;
+                    }
                     String relationship = parser.getAttributeValue(null, "relationship");
                     if(relationship == null) {
                         relationship = CaseIndex.RELATIONSHIP_CHILD;
                     }
-                    
-                    caseForBlock.setIndex(new CaseIndex(indexName, caseType, value, relationship));
+                    //Process blank inputs in the same manner as data fields (IE: Remove the underlying model) 
+                    if(value == null) {
+                        caseForBlock.removeIndex(indexName);
+                    } else {
+                        caseForBlock.setIndex(new CaseIndex(indexName, caseType, value, relationship));
+                    }
                 }
             } else if(action.equals("attachment")) {
                 if(caseForBlock == null) {

--- a/cases/src/org/commcare/cases/model/Case.java
+++ b/cases/src/org/commcare/cases/model/Case.java
@@ -333,4 +333,26 @@ public class Case implements Persistable, IMetaData, Secure {
         if(!data.containsKey(LAST_MODIFIED)) { return getDateOpened();}
         return (Date)data.get(LAST_MODIFIED);
     }
+
+    /**
+     * Removes any potential indices with the provided index name.
+     * 
+     * If the index doesn't currently exist, nothing is changed.
+     *  
+     * @param indexName The name of a case index that should be removed.
+     */
+    public void removeIndex(String indexName) {
+        CaseIndex toRemove = null;
+        
+        for(CaseIndex index : indices) {
+            if(index.mName.equals(indexName)) {
+                toRemove = index;
+                break;
+            }
+        }
+        
+        if(toRemove != null) {
+            indices.remove(toRemove);
+        }
+    }
 }

--- a/cases/src/org/commcare/cases/util/CaseModelProcessor.java
+++ b/cases/src/org/commcare/cases/util/CaseModelProcessor.java
@@ -248,8 +248,9 @@ public class CaseModelProcessor implements ICaseModelProcessor {
             IAnswerData data = child.getValue();
             if (data == null) {
                 c.removeIndex(indexName);
+            } else {
+                c.setIndex(new CaseIndex(indexName, indexType, data.uncast().getString(), relationship));
             }
-            c.setIndex(new CaseIndex(indexName, indexType, data.uncast().getString(), relationship));
             modified = true;
         }
         if (modified) {

--- a/cases/src/org/commcare/cases/util/CaseModelProcessor.java
+++ b/cases/src/org/commcare/cases/util/CaseModelProcessor.java
@@ -248,7 +248,7 @@ public class CaseModelProcessor implements ICaseModelProcessor {
             }
             IAnswerData data = child.getValue();
             if(data == null) {
-                throw new MalformedCaseModelException("Invalid <index> child, supplied index doesn't have a value. at " + child.getRef().toString(true),"<create>");
+                c.removeIndex(indexName);
             }
             c.setIndex(new CaseIndex(indexName, indexType, data.uncast().getString(), relationship));
             modified = true;


### PR DESCRIPTION
Fixes for http://manage.dimagi.com/default.asp?123085 which prevents case indexes being removed in the same manner as other properties.

