### PR TITLE
Remove build param for IDataReference

### DIFF
--- a/application/build.xml
+++ b/application/build.xml
@@ -163,7 +163,7 @@
 					<parameter name="keep ,allowshrinking" value="!abstract class org.javarosa.core.model.instance.* extends org.javarosa.core.model.instance.TreeElement" />
 					<parameter name="keep,  allowshrinking" value="class org.javarosa.core.model.instance.TreeElement" /> <!-- needed to avoid preverify error -->
 					<parameter name="keep , allowshrinking" value="!abstract class org.javarosa.core.model.data.* implements org.javarosa.core.model.data.IAnswerData" />
-					<parameter name="keep  ,allowshrinking" value="!abstract class org.javarosa.model.xform.* implements org.javarosa.core.model.IDataReference" />
+					<parameter name="keep  ,allowshrinking" value="class org.javarosa.model.xform.XPathReference" />
 					<parameter name="keep,   allowshrinking" value="!abstract class org.javarosa.xpath.* implements org.javarosa.core.model.condition.IConditionExpr" />
 					<parameter name="keep ,  allowshrinking" value="!abstract class org.javarosa.xpath.expr.* extends org.javarosa.xpath.expr.XPathExpression" />
 					<parameter name="keep  ,  allowshrinking" value="!abstract class org.javarosa.communication.http.* implements org.javarosa.core.services.transport.ITransportDestination"/>


### PR DESCRIPTION
XPathReference is having trouble being found when getting registered by the PrototypeManager. This is due to having removed IDataReference (https://github.com/dimagi/javarosa/pull/73/) but not updated the commcare J2ME build params.

[ticket](http://manage.dimagi.com/default.asp?167858#936459)