### PR TITLE
Remove TransactionParser's name & namespace fields

### DIFF
--- a/application/src/org/commcare/util/CommCareTransactionParserFactory.java
+++ b/application/src/org/commcare/util/CommCareTransactionParserFactory.java
@@ -58,18 +58,20 @@ public class CommCareTransactionParserFactory implements TransactionParserFactor
 
     /*
      * (non-Javadoc)
-     * @see org.commcare.data.xml.TransactionParserFactory#getParser(java.lang.String, java.lang.String, org.kxml2.io.KXmlParser)
+     * @see org.commcare.data.xml.TransactionParserFactory#getParser(org.kxml2.io.KXmlParser)
      */
-    public TransactionParser getParser(String name, String namespace, KXmlParser parser) {
-        if(name.toLowerCase().equals("case")) {
+    public TransactionParser getParser(KXmlParser parser) {
+        String namespace = parser.getNamespace();
+        String name = parser.getName();
+        if ("case".equalsIgnoreCase(name)) {
             return new AttachableCaseXMLParser(parser, caseTallies, tolerant, (IStorageUtilityIndexed)StorageManager.getStorage(Case.STORAGE_KEY));
-        } else if(name.toLowerCase().equals("registration")) {
+        } else if("registration".equalsIgnoreCase(name)) {
             //TODO: It's possible we want to do the restoreID thing after signalling success, actually. If the
             //restore gets cut off, we don't want to be re-sending the token, since it implies that it worked.
             return new UserXmlParser(parser, restoreId);
-        }  else if(namespace.toLowerCase().equals(LedgerXmlParsers.STOCK_XML_NAMESPACE)) {
+        }  else if(LedgerXmlParsers.STOCK_XML_NAMESPACE.equalsIgnoreCase(namespace)) {
             return new LedgerXmlParsers(parser, (IStorageUtilityIndexed)StorageManager.getStorage(Ledger.STORAGE_KEY));
-        } else if(name.toLowerCase().equals("message")) {
+        } else if("message".equalsIgnoreCase(name)) {
             return new TransactionParser<String> (parser, "message", null) {
 
             String nature = parser.getAttributeValue(null, "nature");
@@ -90,7 +92,7 @@ public class CommCareTransactionParserFactory implements TransactionParserFactor
                 }
             };
 
-        } else if (name.equalsIgnoreCase("Sync")) {
+        } else if ("sync".equalsIgnoreCase(name)) {
             return new TransactionParser<String> (parser, "Sync", null) {
                 public void commit(String parsed) throws IOException {
                     //do nothing
@@ -110,7 +112,7 @@ public class CommCareTransactionParserFactory implements TransactionParserFactor
                     }
                 }
             };
-        } else if(name.toLowerCase().equals("fixture")) {
+        } else if("fixture".equalsIgnoreCase(name)) {
             return new FixtureXmlParser(parser);
         }
         return null;

--- a/application/test/org/commcare/stock/tests/StockXmlParserTests.java
+++ b/application/test/org/commcare/stock/tests/StockXmlParserTests.java
@@ -91,9 +91,8 @@ public class StockXmlParserTests extends TestCase {
 
         TransactionParserFactory factory = new TransactionParserFactory() {
 
-            public TransactionParser getParser(String name, String namespace, KXmlParser parser) {
-
-                if(LedgerXmlParsers.STOCK_XML_NAMESPACE.equals(namespace)) {
+            public TransactionParser getParser(KXmlParser parser) {
+                if (LedgerXmlParsers.STOCK_XML_NAMESPACE.equalsIgnoreCase(parser.getNamespace())) {
                     return new LedgerXmlParsers(parser, null) {
 
                         /* (non-Javadoc)

--- a/backend/src/org/commcare/data/xml/DataModelPullParser.java
+++ b/backend/src/org/commcare/data/xml/DataModelPullParser.java
@@ -119,14 +119,11 @@ public class DataModelPullParser extends ElementParser<Boolean> {
             }
 
             String name = parser.getName();
-            String namespace = parser.getNamespace();
-
-            int depth = parser.getDepth();
             if (name == null) {
                 continue;
             }
 
-            TransactionParser transaction = factory.getParser(name, namespace, parser);
+            TransactionParser transaction = factory.getParser(parser);
             if (transaction == null) {
                 //nothing to be done for this element, recurse?
                 if (deep) {
@@ -140,7 +137,7 @@ public class DataModelPullParser extends ElementParser<Boolean> {
                         transaction.parse();
                     } catch (Exception e) {
                         e.printStackTrace();
-                        deal(e, depth, name);
+                        deal(e, parser.getDepth(), name);
                     }
                 } else {
                     transaction.parse();

--- a/backend/src/org/commcare/data/xml/TransactionParser.java
+++ b/backend/src/org/commcare/data/xml/TransactionParser.java
@@ -1,6 +1,3 @@
-/**
- *
- */
 package org.commcare.data.xml;
 
 import java.io.IOException;
@@ -12,20 +9,8 @@ import org.kxml2.io.KXmlParser;
  * @author ctsims
  */
 public abstract class TransactionParser<T> extends ElementParser<T> {
-
-    String name;
-    String namespace;
-
-
-    public TransactionParser(KXmlParser parser, String name, String namespace) {
+    public TransactionParser(KXmlParser parser) {
         super(parser);
-    }
-
-    public boolean parses(String name, String namespace) {
-        if (name.toLowerCase().equals(this.name)) {
-            return true;
-        }
-        return false;
     }
 
     public abstract void commit(T parsed) throws IOException;

--- a/backend/src/org/commcare/data/xml/TransactionParserFactory.java
+++ b/backend/src/org/commcare/data/xml/TransactionParserFactory.java
@@ -3,5 +3,5 @@ package org.commcare.data.xml;
 import org.kxml2.io.KXmlParser;
 
 public interface TransactionParserFactory {
-    TransactionParser getParser(String name, String namespace, KXmlParser parser);
+    TransactionParser getParser(KXmlParser parser);
 }

--- a/backend/src/org/commcare/xml/BestEffortBlockParser.java
+++ b/backend/src/org/commcare/xml/BestEffortBlockParser.java
@@ -25,7 +25,7 @@ public abstract class BestEffortBlockParser extends TransactionParser<Hashtable<
     String[] elements;
 
     public BestEffortBlockParser(KXmlParser parser, String name, String namespace, String[] elements) {
-        super(parser, name, namespace);
+        super(parser);
         this.elements = elements;
     }
 

--- a/backend/src/org/commcare/xml/CaseXmlParser.java
+++ b/backend/src/org/commcare/xml/CaseXmlParser.java
@@ -51,7 +51,7 @@ public class CaseXmlParser extends TransactionParser<Case> {
      *                               contains create actions for cases which already exist.
      */
     public CaseXmlParser(KXmlParser parser, int[] tallies, boolean acceptCreateOverwrites, IStorageUtilityIndexed storage) {
-        super(parser, "case", null);
+        super(parser);
         this.tallies = tallies;
         this.acceptCreateOverwrites = acceptCreateOverwrites;
         this.storage = storage;

--- a/backend/src/org/commcare/xml/FixtureXmlParser.java
+++ b/backend/src/org/commcare/xml/FixtureXmlParser.java
@@ -37,7 +37,7 @@ public class FixtureXmlParser extends TransactionParser<FormInstance> {
     }
 
     public FixtureXmlParser(KXmlParser parser, boolean overwrite, IStorageUtilityIndexed<FormInstance> storage) {
-        super(parser, "fixture", null);
+        super(parser);
         this.overwrite = overwrite;
         this.storage = storage;
     }

--- a/backend/src/org/commcare/xml/LedgerXmlParsers.java
+++ b/backend/src/org/commcare/xml/LedgerXmlParsers.java
@@ -50,7 +50,7 @@ public class LedgerXmlParsers extends TransactionParser<Ledger[]> {
      * @param parser The parser for incoming XML.
      */
     public LedgerXmlParsers(KXmlParser parser, IStorageUtilityIndexed<Ledger> storage) {
-        super(parser, null, null);
+        super(parser);
         this.storage = storage;
     }
 


### PR DESCRIPTION
Since TransactionParser and its extensions didn't use the following, remove them:
 -  'parses' method
 - 'name' and 'namespace' fields

Change TransactionParserFactory's getParser to not take in a name or namespace field. These were rarely used, and in the cases that they were, the name/namespace values were obtained from the parser argument, and hence were redundant.

Cross requested with https://github.com/dimagi/commcare-odk/pull/311