### PR TITLE
J2ME Fix for Module Filters

### DIFF
--- a/application/src/org/commcare/util/CommCareSessionController.java
+++ b/application/src/org/commcare/util/CommCareSessionController.java
@@ -71,10 +71,11 @@ public class CommCareSessionController {
         entryTable.clear();
         menuTable.clear();
         Enumeration en = session.platform.getInstalledSuites().elements();
-        EvaluationContext ec  = null;
         while(en.hasMoreElements()) {
             Suite suite = (Suite)en.nextElement();
             for(Menu m : suite.getMenus()) {
+                //don't do this lazily for now because it changes per module
+                EvaluationContext ec  = null;
                 try {
                     XPathExpression relevance = m.getMenuRelevance();
                     if (relevance != null) {


### PR DESCRIPTION
Fixes 2.21 problem where Nokia Apps won't start up due to module filter not including new instances depending on the menu declaration