### PR TITLE
J2ME fix for TransactionParser refactor

### DIFF
--- a/application/src/org/commcare/util/CommCareTransactionParserFactory.java
+++ b/application/src/org/commcare/util/CommCareTransactionParserFactory.java
@@ -72,7 +72,7 @@ public class CommCareTransactionParserFactory implements TransactionParserFactor
         }  else if(LedgerXmlParsers.STOCK_XML_NAMESPACE.equalsIgnoreCase(namespace)) {
             return new LedgerXmlParsers(parser, (IStorageUtilityIndexed)StorageManager.getStorage(Ledger.STORAGE_KEY));
         } else if("message".equalsIgnoreCase(name)) {
-            return new TransactionParser<String> (parser, "message", null) {
+            return new TransactionParser<String>(parser) {
 
             String nature = parser.getAttributeValue(null, "nature");
 
@@ -93,7 +93,7 @@ public class CommCareTransactionParserFactory implements TransactionParserFactor
             };
 
         } else if ("sync".equalsIgnoreCase(name)) {
-            return new TransactionParser<String> (parser, "Sync", null) {
+            return new TransactionParser<String>(parser) {
                 public void commit(String parsed) throws IOException {
                     //do nothing
                 }

--- a/application/src/org/commcare/xml/UserXmlParser.java
+++ b/application/src/org/commcare/xml/UserXmlParser.java
@@ -24,7 +24,7 @@ public class UserXmlParser extends TransactionParser<User> {
     }
 
     public UserXmlParser(KXmlParser parser, String syncToken) {
-        super(parser, "registration", null);
+        super(parser);
         this.syncToken = syncToken;
     }
 


### PR DESCRIPTION
https://github.com/dimagi/commcare/pull/84 was breaking J2ME build because it was calling methods removed in the aforementioned PR.