### PR TITLE
Missed method invocations during ResourceTable refactor

### DIFF
--- a/application/src/org/commcare/util/ResourceTableSubreport.java
+++ b/application/src/org/commcare/util/ResourceTableSubreport.java
@@ -35,7 +35,7 @@ public class ResourceTableSubreport implements DeviceReportElement {
                 try {
                     o.attribute(null, "id", r.getResourceId());
                     o.attribute(null, "version", String.valueOf(r.getVersion()));
-                    DeviceReportState.writeText(o, "status", ResourceTable.getStatus(r.getStatus()));
+                    DeviceReportState.writeText(o, "status", ResourceTable.getStatusString(r.getStatus()));
                 }finally {
                     o.endTag(DeviceReportState.XMLNS, "resource");
                 }

--- a/backend/src/org/commcare/resources/model/ResourceTable.java
+++ b/backend/src/org/commcare/resources/model/ResourceTable.java
@@ -733,7 +733,7 @@ public class ResourceTable {
         return header.append(resourceDetails.toString()).append(header.toString()).toString();
     }
 
-    private static String getStatusString(int status) {
+    public static String getStatusString(int status) {
         switch (status) {
             case Resource.RESOURCE_STATUS_UNINITIALIZED:
                 return "Uninitialized";

--- a/backend/src/org/commcare/util/CommCarePlatform.java
+++ b/backend/src/org/commcare/util/CommCarePlatform.java
@@ -92,6 +92,15 @@ public class CommCarePlatform implements CommCareInstance {
     public ResourceTable stageUpgradeTable(ResourceTable global,
                                            ResourceTable incoming,
                                            ResourceTable recovery,
+                                           boolean clearProgress) 
+        throws UnfullfilledRequirementsException, StorageFullException, UnresolvedResourceException {
+        Profile current = getCurrentProfile();
+        return stageUpgradeTable(global, incoming, recovery, current.getAuthReference(), clearProgress);
+    }
+
+    public ResourceTable stageUpgradeTable(ResourceTable global,
+                                           ResourceTable incoming,
+                                           ResourceTable recovery,
                                            String profileRef,
                                            boolean clearProgress)
             throws UnfullfilledRequirementsException, StorageFullException, UnresolvedResourceException {


### PR DESCRIPTION
Fix for crashing build caused by merging https://github.com/dimagi/commcare/pull/78

Turns out I refactored a bit too aggressively due to not noticing some function calls made by utils