### PR TITLE
Check if commandId is null in getEntriesForCommand to prevent NPE

### DIFF
--- a/backend/src/org/commcare/util/CommCareSession.java
+++ b/backend/src/org/commcare/util/CommCareSession.java
@@ -225,8 +225,12 @@ public class CommCareSession {
      * an entry on the stack
      */
     public SessionDatum getNeededDatum() {
-        Entry entry = getEntriesForCommand(getCommand()).elementAt(0);
-        return getNeededDatum(entry);
+        Vector<Entry> entries = getEntriesForCommand(getCommand());
+        if (entries.size() > 0) {
+            return getNeededDatum(entries.elementAt(0));
+        } else {
+            return null;
+        }
     }
 
     /**
@@ -235,14 +239,13 @@ public class CommCareSession {
      */
     public SessionDatum getNeededDatum(Entry entry) {
         int nextVal = getData().size();
-        //If we've already retrieved all data needed, return null.
         if (nextVal >= entry.getSessionDataReqs().size()) {
+            // we've already retrieved all data needed.
             return null;
         }
 
-        //Otherwise retrieve the needed value
-        SessionDatum datum = entry.getSessionDataReqs().elementAt(nextVal);
-        return datum;
+        // retrieve the needed value
+        return entry.getSessionDataReqs().elementAt(nextVal);
     }
 
     public Detail getDetail(String id) {
@@ -431,7 +434,6 @@ public class CommCareSession {
      * @return Evaluation context for a command in the installed app
      */
     public EvaluationContext getEvaluationContext(InstanceInitializationFactory iif, String command) {
-
         if (command == null) {
             return new EvaluationContext(null);
         }
@@ -443,7 +445,6 @@ public class CommCareSession {
             String key = (String)en.nextElement();
             instances.get(key).initialize(iif, key);
         }
-
 
         return new EvaluationContext(null, instances);
     }
@@ -723,12 +724,14 @@ public class CommCareSession {
      */
     public boolean isViewCommand(String command) {
         Vector<Entry> entries = this.getEntriesForCommand(command);
-        Entry prototype = entries.elementAt(0);
+        if (entries.size() == 1) {
+            Entry prototype = entries.elementAt(0);
 
-        // NOTE: We shouldn't need the "" here, but we're avoiding making changes to
-        // commcare core for release issues
-        return (entries.size() == 1 &&
-                (prototype.getXFormNamespace() == null ||
-                        prototype.getXFormNamespace().equals("")));
+            // NOTE: We shouldn't need the "" here, but we're avoiding making changes to
+            // commcare core for release issues
+            return prototype.getXFormNamespace() == null || prototype.getXFormNamespace().equals("");
+        } else {
+            return false;
+        }
     }
 }

--- a/backend/src/org/commcare/util/CommCareSession.java
+++ b/backend/src/org/commcare/util/CommCareSession.java
@@ -72,6 +72,12 @@ public class CommCareSession {
         Hashtable<String, Entry> map = platform.getMenuMap();
         Menu menu = null;
         Entry entry = null;
+        Vector<Entry> entries = new Vector<Entry>();
+
+        if (commandId == null) {
+            return entries;
+        }
+
         top:
         for (Suite s : platform.getInstalledSuites()) {
             for (Menu m : s.getMenus()) {
@@ -88,7 +94,6 @@ public class CommCareSession {
             }
         }
 
-        Vector<Entry> entries = new Vector<Entry>();
         if (entry != null) {
             entries.addElement(entry);
         }
@@ -262,6 +267,9 @@ public class CommCareSession {
     }
 
     public Suite getCurrentSuite() {
+        if (currentCmd == null) {
+            return null;
+        }
         for (Suite s : platform.getInstalledSuites()) {
             for (Menu m : s.getMenus()) {
                 //We need to see if everything in this menu can be matched


### PR DESCRIPTION
Trying to solve this crash from the google play store crash reports
```
java.lang.RuntimeException: Unable to start activity ComponentInfo{org.commcare.dalvik/org.commcare.dalvik.activities.EntitySelectActivity}: java.lang.NullPointerException
at android.app.ActivityThread.performLaunchActivity(ActivityThread.java:1659)
at android.app.ActivityThread.handleLaunchActivity(ActivityThread.java:1675)
at android.app.ActivityThread.access$1500(ActivityThread.java:121)
at android.app.ActivityThread$H.handleMessage(ActivityThread.java:943)
at android.os.Handler.dispatchMessage(Handler.java:99)
at android.os.Looper.loop(Looper.java:130)
at android.app.ActivityThread.main(ActivityThread.java:3701)
at java.lang.reflect.Method.invokeNative(Native Method)
at java.lang.reflect.Method.invoke(Method.java:507)
at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:866)
at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:624)
at dalvik.system.NativeStart.main(Native Method)
Caused by: java.lang.NullPointerException
at org.commcare.util.CommCareSession.getEntriesForCommand(CommCareSession.java:79)
at org.commcare.util.CommCareSession.getEntriesForCommand(CommCareSession.java:79)
at org.commcare.util.CommCareSession.getEntriesForCommand(CommCareSession.java:68)
at org.commcare.util.CommCareSession.getNeededDatum(CommCareSession.java:223)
at org.commcare.dalvik.activities.EntitySelectActivity.onCreate(EntitySelectActivity.java:162)
at android.app.Instrumentation.callActivityOnCreate(Instrumentation.java:1047)
at android.app.ActivityThread.performLaunchActivity(ActivityThread.java:1623)
... 11 more
```

EntitySelectActivity calls getNeededDatum https://github.com/dimagi/commcare-odk/blob/master/app/src/org/commcare/dalvik/activities/EntitySelectActivity.java#L168, which results in an NPE because the currentCmd field is null, resulting in commandId being null https://github.com/dimagi/commcare/blob/master/backend/src/org/commcare/util/CommCareSession.java#L79 

This PR prevents the null pointer exception. I am uncertain if just preventing this crash is the right way to go, perhaps I should be addressing the logical root of the problem?