### PR TITLE
Remove non-informationative javadocs method annotations

### DIFF
--- a/backend/src/org/commcare/resources/model/CommCareOTARestoreListener.java
+++ b/backend/src/org/commcare/resources/model/CommCareOTARestoreListener.java
@@ -31,16 +31,12 @@ public abstract interface CommCareOTARestoreListener {
     /**
      * Called by the parseBlock method every time the restore task successfully
      * parses a new block of the restore form
-     *
-     * @param numberCompleted
      */
     public abstract void onUpdate(int numberCompleted);
 
     /**
      * Called when the parser encounters the "<items>" property in the restore file
      * Enables the progress bar
-     *
-     * @param totalItemCount
      */
     public abstract void setTotalForms(int totalItemCount);
 

--- a/backend/src/org/commcare/resources/model/Resource.java
+++ b/backend/src/org/commcare/resources/model/Resource.java
@@ -1,6 +1,3 @@
-/**
- *
- */
 package org.commcare.resources.model;
 
 import java.io.DataInputStream;
@@ -145,7 +142,6 @@ public class Resource implements Persistable, IMetaData {
      * @param locations  A set of locations from which this resource's definition
      *                   can be retrieved. Note that this vector is copied and should not be changed
      *                   after being passed in here.
-     * @param descriptor
      */
     public Resource(int version, String id, Vector<ResourceLocation> locations, String descriptor) {
         this.version = version;
@@ -291,8 +287,6 @@ public class Resource implements Persistable, IMetaData {
     /**
      * Take on all identifiers from the incoming
      * resouce, so as to replace it in a different table.
-     *
-     * @param source
      */
     public void mimick(Resource source) {
         this.guid = source.guid;

--- a/backend/src/org/commcare/resources/model/ResourceInstaller.java
+++ b/backend/src/org/commcare/resources/model/ResourceInstaller.java
@@ -1,6 +1,3 @@
-/**
- *
- */
 package org.commcare.resources.model;
 
 import java.util.Vector;
@@ -49,11 +46,7 @@ public interface ResourceInstaller<T extends CommCareInstance> extends Externali
      * current, and maintaining upgrade status against master.
      *
      * @param r        The resource to be stepped
-     * @param location
-     * @param ref
      * @param table    the table where the resource is being managed
-     * @param instance
-     * @param upgrade
      * @return Whether the resource was able to complete an installation
      * step in the current circumstances.
      * @throws UnresolvedResourceException       If the local resource

--- a/backend/src/org/commcare/suite/model/Action.java
+++ b/backend/src/org/commcare/suite/model/Action.java
@@ -1,6 +1,3 @@
-/**
- *
- */
 package org.commcare.suite.model;
 
 import java.io.DataInputStream;
@@ -36,9 +33,6 @@ public class Action implements Externalizable {
     /**
      * Creates an Action model with the associated display details and stack
      * operations set.
-     *
-     * @param display
-     * @param stackOps
      */
     public Action(DisplayUnit display, Vector<StackOperation> stackOps) {
         this.display = display;

--- a/backend/src/org/commcare/suite/model/AssertionSet.java
+++ b/backend/src/org/commcare/suite/model/AssertionSet.java
@@ -1,6 +1,3 @@
-/**
- *
- */
 package org.commcare.suite.model;
 
 import java.io.DataInputStream;
@@ -37,10 +34,6 @@ public class AssertionSet implements Externalizable {
      * NOTE: The tests are _not parsed here_ to test their xpath expressions.
      * They should be tested _before_ being passed in (we don't do so here
      * to permit retaining the locality of which expression failed).
-     *
-     * @param xpathExpressions
-     * @param messages
-     * @throws XPathSyntaxException
      */
     public AssertionSet(Vector<String> xpathExpressions, Vector<Text> messages) {
         //First, make sure things are set up correctly

--- a/backend/src/org/commcare/suite/model/Detail.java
+++ b/backend/src/org/commcare/suite/model/Detail.java
@@ -1,6 +1,3 @@
-/**
- *
- */
 package org.commcare.suite.model;
 
 import org.commcare.util.GridCoordinate;
@@ -148,8 +145,6 @@ public class Detail implements Externalizable {
      * Whether this detail is expected to be so huge in scope that
      * the platform should limit its strategy for loading it to be asynchronous
      * and cached on special keys.
-     *
-     * @return
      */
     public boolean useAsyncStrategy() {
         for (DetailField f : getFields()) {

--- a/backend/src/org/commcare/suite/model/DetailField.java
+++ b/backend/src/org/commcare/suite/model/DetailField.java
@@ -1,6 +1,3 @@
-/**
- *
- */
 package org.commcare.suite.model;
 
 import java.io.DataInputStream;
@@ -348,9 +345,6 @@ public class DetailField implements Externalizable {
             field.sortDirection = sortDirection;
         }
 
-        /**
-         * @param sortType
-         */
         public void setSortType(int sortType) {
             field.sortType = sortType;
         }
@@ -386,12 +380,10 @@ public class DetailField implements Externalizable {
 
         public void setCssID(String id) {
             field.cssID = id;
-
         }
 
         public void setBackground(Text background) {
             field.background = background;
-
         }
     }
 }

--- a/backend/src/org/commcare/suite/model/SessionDatum.java
+++ b/backend/src/org/commcare/suite/model/SessionDatum.java
@@ -1,6 +1,3 @@
-/**
- *
- */
 package org.commcare.suite.model;
 
 import java.io.DataInputStream;
@@ -150,15 +147,11 @@ public class SessionDatum implements Externalizable {
         ExtUtil.writeString(out, ExtUtil.emptyIfNull(value));
     }
 
-
     /**
      * Takes an ID and identifies a reference in the provided context which corresponds
      * to that element if one can be found.
      *
      * NOT GUARANTEED TO WORK! May return an entity if one exists
-     *
-     * @param uniqueid
-     * @return
      */
     public TreeReference getEntityFromID(EvaluationContext ec, String elementId) {
         //The uniqueid here is the value selected, so we can in theory track down the value we're looking for.

--- a/backend/src/org/commcare/util/CommCarePlatform.java
+++ b/backend/src/org/commcare/util/CommCarePlatform.java
@@ -1,6 +1,3 @@
-/**
- *
- */
 package org.commcare.util;
 
 import java.util.Enumeration;
@@ -242,10 +239,6 @@ public class CommCarePlatform implements CommCareInstance {
      *
      * NOTE: this does not currently repair resources which have been corrupted, merely returns all of the
      * tables to the appropriate states
-     *
-     * @param global
-     * @param incoming
-     * @param recovery
      */
     private void repair(ResourceTable global, ResourceTable incoming, ResourceTable recovery) {
         //First we need to figure out what state we're in currently. There are a few possibilities

--- a/backend/src/org/commcare/util/CommCareSession.java
+++ b/backend/src/org/commcare/util/CommCareSession.java
@@ -448,9 +448,6 @@ public class CommCareSession {
 
     /**
      * Deprecated. Fires a single stack operation.
-     *
-     * @param op
-     * @param ec
      */
     public boolean executeStackOperation(StackOperation op, EvaluationContext ec) {
         Vector<StackOperation> ops = new Vector<StackOperation>();
@@ -466,9 +463,6 @@ public class CommCareSession {
      * against the most recent frame. (IE: If a new frame is pushed here, xpath expressions
      * calculated within it will be evaluated against the starting, but <push> actions
      * will happen against the newly pushed frame)
-     *
-     * @param ops
-     * @param ec
      */
     public boolean executeStackOperations(Vector<StackOperation> ops, EvaluationContext ec) {
         //the on deck frame is the frame that is the target of operations that execute

--- a/backend/src/org/commcare/util/SessionFrame.java
+++ b/backend/src/org/commcare/util/SessionFrame.java
@@ -1,6 +1,3 @@
-/**
- *
- */
 package org.commcare.util;
 
 import java.util.Vector;
@@ -109,8 +106,6 @@ public class SessionFrame {
      *
      * Compatibility is determined by checking that each step in the previous
      * snapshot is matched by an identical step in the current snapshot.
-     *
-     * @return
      */
     public boolean isSnapshotIncompatible() {
         synchronized (steps) {
@@ -140,7 +135,6 @@ public class SessionFrame {
             this.snapshot = null;
         }
     }
-
 
     /**
      * @return Whether this frame is dead or not. Dead frames have finished their session

--- a/cases/src/org/commcare/cases/CaseManagementModule.java
+++ b/cases/src/org/commcare/cases/CaseManagementModule.java
@@ -1,22 +1,3 @@
-/*
- * Copyright (C) 2009 JavaRosa
- *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not
- * use this file except in compliance with the License. You may obtain a copy of
- * the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
- * the License.
- */
-
-/**
- *
- */
 package org.commcare.cases;
 
 import org.commcare.cases.ledger.Ledger;
@@ -37,5 +18,4 @@ public class CaseManagementModule implements IModule {
         StorageManager.registerStorage(Case.STORAGE_KEY, Case.class);
         StorageManager.registerStorage(Ledger.STORAGE_KEY, Ledger.class);
     }
-
 }

--- a/cases/src/org/commcare/cases/ledger/Ledger.java
+++ b/cases/src/org/commcare/cases/ledger/Ledger.java
@@ -1,6 +1,3 @@
-/**
- *
- */
 package org.commcare.cases.ledger;
 
 import java.io.DataInputStream;
@@ -47,8 +44,6 @@ public class Ledger implements Persistable, IMetaData {
 
     /**
      * Get the ID of the linked entity associated with this Ledger record
-     *
-     * @return
      */
     public String getEntiyId() {
         return entityId;
@@ -140,10 +135,6 @@ public class Ledger implements Persistable, IMetaData {
 
     /**
      * Sets the value of an entry in the specified section of this ledger
-     *
-     * @param sectionId
-     * @param entryId
-     * @param quantity
      */
     public void setEntry(String sectionId, String entryId, int quantity) {
         if (!sections.containsKey(sectionId)) {

--- a/cases/src/org/commcare/cases/model/Case.java
+++ b/cases/src/org/commcare/cases/model/Case.java
@@ -1,22 +1,3 @@
-/*
- * Copyright (C) 2009 JavaRosa
- *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not
- * use this file except in compliance with the License. You may obtain a copy of
- * the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
- * the License.
- */
-
-/**
- *
- */
 package org.commcare.cases.model;
 
 import java.io.DataInputStream;
@@ -83,51 +64,30 @@ public class Case implements Persistable, IMetaData, Secure {
         setLastModified(dateOpened);
     }
 
-    /**
-     * @return the typeId
-     */
     public String getTypeId() {
         return typeId;
     }
 
-    /**
-     * @param typeId the typeId to set
-     */
     public void setTypeId(String typeId) {
         this.typeId = typeId;
     }
 
-    /**
-     * @return The name of this case
-     */
     public String getName() {
         return name;
     }
 
-    /**
-     * @param The name of this case
-     */
     public void setName(String name) {
         this.name = name;
     }
 
-    /**
-     * @return True if this case is closed, false otherwise.
-     */
     public boolean isClosed() {
         return closed;
     }
 
-    /**
-     * @param Whether or not this case should be recorded as closed
-     */
     public void setClosed(boolean closed) {
         this.closed = closed;
     }
 
-    /**
-     * @return the recordId
-     */
     public int getID() {
         return recordId;
     }
@@ -144,9 +104,6 @@ public class Case implements Persistable, IMetaData, Secure {
         data.put(org.javarosa.core.api.Constants.USER_ID_KEY, id);
     }
 
-    /**
-     * @param id the id to set
-     */
     public void setCaseId(String id) {
         this.id = id;
     }
@@ -155,16 +112,10 @@ public class Case implements Persistable, IMetaData, Secure {
         return id;
     }
 
-    /**
-     * @return the dateOpened
-     */
     public Date getDateOpened() {
         return dateOpened;
     }
 
-    /**
-     * @param dateOpened the dateOpened to set
-     */
     public void setDateOpened(Date dateOpened) {
         this.dateOpened = dateOpened;
     }
@@ -319,9 +270,6 @@ public class Case implements Persistable, IMetaData, Secure {
 
     private static final String LAST_MODIFIED = "last_modified";
 
-    /**
-     * @param lastModified
-     */
     public void setLastModified(Date lastModified) {
         if (lastModified == null) {
             throw new NullPointerException("Case date last modified cannot be null");


### PR DESCRIPTION
Remove javadoc method annotations that don't actually contain any information.

(I'm bored in the car on a roadtrip and can't concentrate enough to do any real coding)