### PR TITLE
Breakup prepareResources into two separate methods

### DIFF
--- a/backend/src/org/commcare/util/CommCarePlatform.java
+++ b/backend/src/org/commcare/util/CommCarePlatform.java
@@ -160,7 +160,7 @@ public class CommCarePlatform implements CommCareInstance {
 
         incoming.addResource(r, incoming.getInstallers().getProfileInstaller(false), null);
 
-        incoming.prepareResources(global, this, APP_PROFILE_RESOURCE_ID);
+        incoming.prepareResourcesUpTo(global, this, APP_PROFILE_RESOURCE_ID);
 
         return incoming;
     }


### PR DESCRIPTION
Refactor that moves logic out of prepareResources that stops the resource preparation after a specific resource is instantiated.