### PR TITLE
Empty Case ID parser fix + Test

### DIFF
--- a/backend/src/org/commcare/xml/CaseXmlParser.java
+++ b/backend/src/org/commcare/xml/CaseXmlParser.java
@@ -61,7 +61,7 @@ public class CaseXmlParser extends TransactionParser<Case> {
         this.checkNode("case");
 
         String caseId = parser.getAttributeValue(null, "case_id");
-        if (caseId == null) {
+        if (caseId == null || caseId.equals("")) {
             throw new InvalidStructureException("<case> block with no case_id attribute.", this.parser);
         }
 
@@ -172,7 +172,7 @@ public class CaseXmlParser extends TransactionParser<Case> {
                     String value = parser.nextText().trim();
 
                     //Remove any ambiguity associated with empty values
-                    if (value == "") {
+                    if (value.equals("")) {
                         value = null;
                     }
                     String relationship = parser.getAttributeValue(null, "relationship");

--- a/tests/test/org/commcare/cases/test/BadCaseXMLTests.java
+++ b/tests/test/org/commcare/cases/test/BadCaseXMLTests.java
@@ -2,6 +2,7 @@ package org.commcare.cases.test;
 
 import org.commcare.util.mocks.MockDataUtils;
 import org.commcare.util.mocks.MockUserDataSandbox;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -25,7 +26,8 @@ public class BadCaseXMLTests {
         //Expected - Fail silently (TODO: Fix?)
         MockDataUtils.parseIntoSandbox(this.getClass().getResourceAsStream("/case_create_broken_no_caseid.xml"), sandbox);
 
+
         //Make sure that we didn't make a case entry for the bad case though
-        //assertEquals("Case XML with no id should not have created a case record", sandbox.getCaseStorage().getNumRecords(), 0);
+        Assert.assertEquals("Case XML with no id should not have created a case record", sandbox.getCaseStorage().getNumRecords(), 0);
     }
 }

--- a/tests/test/org/commcare/cases/test/CaseParseAndReadTest.java
+++ b/tests/test/org/commcare/cases/test/CaseParseAndReadTest.java
@@ -7,6 +7,7 @@ import org.commcare.util.mocks.MockUserDataSandbox;
 import org.javarosa.core.io.StreamsUtil;
 import org.javarosa.core.model.instance.ExternalDataInstance;
 import org.javarosa.model.xform.DataModelSerializer;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.kxml2.kdom.Document;
@@ -15,8 +16,6 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-
-import static org.junit.Assert.assertEquals;
 
 /**
  * Test suite to verify end-to-end parsing of inbound case XML
@@ -53,7 +52,7 @@ public class CaseParseAndReadTest {
             //NOTE: The DOM's definitely don't match here, so the strings cannot be the same.
             //The reason we are asserting equality is because the delta between the strings is
             //likely to do a good job of contextualizing where the DOM's don't match.
-            assertEquals("CaseDB output did not match expected structure(" + e.getMessage()+ ")",new String(dumpStream(caseDbState)), new String(parsedDb));
+            Assert.assertEquals("CaseDB output did not match expected structure(" + e.getMessage() + ")", new String(dumpStream(caseDbState)), new String(parsedDb));
         }
     }
 


### PR DESCRIPTION
Fixed empty caseid attribute being recorded as empty strings instead of null values, and associated test