### PR TITLE
Improve stepBack() logic for CommCareSession

### DIFF
--- a/backend/src/org/commcare/util/CommCareSession.java
+++ b/backend/src/org/commcare/util/CommCareSession.java
@@ -128,7 +128,7 @@ public class CommCareSession {
      * proceed
      *
      * @return 1 of the 4 STATE strings declared at the top of SessionFrame.java, or null if
-     * could not be determined
+     * the session does not need anything else to proceed
      */
     public String getNeededData() {
 
@@ -289,18 +289,19 @@ public class CommCareSession {
     }
 
     public void stepBack() {
+        // Pop the first thing off of the stack frame, no matter what
         StackFrameStep recentPop = frame.popStep();
-        //TODO: Check the "base state" of the frame
-        //after popping to see if we invalidated the
-        //stack
-
         syncState();
-        popped = recentPop;
-        //If we've stepped back into a computed value, we actually want to go back again, since evaluating that
-        //element will just result in moving forward again.
-        if (this.getNeededData() == SessionFrame.STATE_DATUM_COMPUTED) {
-            stepBack();
+
+        // Keep popping things off until the value of needed data indicates that we are back to
+        // somewhere where we are waiting for user-provided input
+        while (this.getNeededData() == null ||
+                this.getNeededData() == SessionFrame.STATE_DATUM_COMPUTED) {
+            recentPop = frame.popStep();
+            syncState();
         }
+
+        popped = recentPop;
     }
 
     public void setDatum(String keyId, String value) {

--- a/backend/src/org/commcare/util/CommCareSession.java
+++ b/backend/src/org/commcare/util/CommCareSession.java
@@ -290,17 +290,19 @@ public class CommCareSession {
 
     public void stepBack() {
         // Pop the first thing off of the stack frame, no matter what
-        StackFrameStep recentPop = frame.popStep();
-        syncState();
+        popSessionFrameStack();
 
         // Keep popping things off until the value of needed data indicates that we are back to
         // somewhere where we are waiting for user-provided input
         while (this.getNeededData() == null ||
                 this.getNeededData() == SessionFrame.STATE_DATUM_COMPUTED) {
-            recentPop = frame.popStep();
-            syncState();
+            popSessionFrameStack();
         }
+    }
 
+    private void popSessionFrameStack() {
+        StackFrameStep recentPop = frame.popStep();
+        syncState();
         popped = recentPop;
     }
 

--- a/backend/src/org/commcare/util/CommCareSession.java
+++ b/backend/src/org/commcare/util/CommCareSession.java
@@ -302,6 +302,7 @@ public class CommCareSession {
 
     private void popSessionFrameStack() {
         StackFrameStep recentPop = frame.popStep();
+        //TODO: Check the "base state" of the frame after popping to see if we invalidated the stack
         syncState();
         popped = recentPop;
     }

--- a/backend/src/org/commcare/util/SessionFrame.java
+++ b/backend/src/org/commcare/util/SessionFrame.java
@@ -24,7 +24,7 @@ public class SessionFrame {
     public static final String STATE_COMMAND_ID = "COMMAND_ID";
 
     /**
-     * CommCare needs the ID of a Case to proceed *
+     * CommCare needs any piece of information coming from a datum val (other than a computed datum)
      */
     public static final String STATE_DATUM_VAL = "CASE_ID";
 


### PR DESCRIPTION
Fix for bugs http://manage.dimagi.com/default.asp?169122 and http://manage.dimagi.com/default.asp?178871

@ctsims - This is a slightly different approach than what we talked about, but I realized that our original plan doesn't work, for example in the following case: If you have 2 COMMAND_ID selections in a row, and you press back from the 2nd one, you do not actually want to go back 2 steps. 

So, my thought process with the alternative solution used here is that when a user presses back, we basically want to end up at the last nearest place where there was a user-inputted decision. I tested this out with a couple of different apps and it has the desired behavior in everything I tried, but let me know if you can think of anywhere that this would break.