### PR TITLE
reorganize test directory

### DIFF
--- a/tests/test/org/commcare/backend/suite/model/test/ProfileTests.java
+++ b/tests/test/org/commcare/backend/suite/model/test/ProfileTests.java
@@ -1,9 +1,9 @@
-package org.commcare.model.test;
+package org.commcare.backend.suite.model.test;
 
 import org.commcare.resources.model.Resource;
 import org.commcare.resources.model.ResourceTable;
 import org.commcare.suite.model.Profile;
-import org.commcare.test.utils.PersistableSandbox;
+import org.commcare.test.utilities.PersistableSandbox;
 import org.commcare.util.CommCareConfigEngine;
 import org.commcare.util.mocks.LivePrototypeFactory;
 import org.commcare.xml.ProfileParser;

--- a/tests/test/org/commcare/backend/suite/model/test/StackFrameStepTests.java
+++ b/tests/test/org/commcare/backend/suite/model/test/StackFrameStepTests.java
@@ -1,7 +1,7 @@
-package org.commcare.model.test;
+package org.commcare.backend.suite.model.test;
 
 import org.commcare.suite.model.StackFrameStep;
-import org.commcare.test.utils.PersistableSandbox;
+import org.commcare.test.utilities.PersistableSandbox;
 import org.commcare.util.SessionFrame;
 
 import org.junit.Before;

--- a/tests/test/org/commcare/backend/test/TemplateStructureTest.java
+++ b/tests/test/org/commcare/backend/test/TemplateStructureTest.java
@@ -1,5 +1,6 @@
-package org.commcare.test.utilities;
+package org.commcare.backend.test;
 
+import org.commcare.test.utilities.MockApp;
 import org.commcare.util.mocks.SessionWrapper;
 import org.junit.Assert;
 

--- a/tests/test/org/commcare/cases/ledger/test/LedgerAndCaseQueryTest.java
+++ b/tests/test/org/commcare/cases/ledger/test/LedgerAndCaseQueryTest.java
@@ -1,6 +1,6 @@
 package org.commcare.cases.ledger.test;
 
-import org.commcare.cases.CaseTestUtils;
+import org.commcare.test.utilities.CaseTestUtils;
 import org.commcare.util.mocks.MockDataUtils;
 import org.commcare.util.mocks.MockUserDataSandbox;
 import org.javarosa.core.model.condition.EvaluationContext;

--- a/tests/test/org/commcare/cases/ledger/test/LedgerParseAndQueryTest.java
+++ b/tests/test/org/commcare/cases/ledger/test/LedgerParseAndQueryTest.java
@@ -1,6 +1,6 @@
 package org.commcare.cases.ledger.test;
 
-import org.commcare.cases.CaseTestUtils;
+import org.commcare.test.utilities.CaseTestUtils;
 import org.commcare.util.mocks.MockDataUtils;
 import org.commcare.util.mocks.MockUserDataSandbox;
 import org.javarosa.core.model.condition.EvaluationContext;

--- a/tests/test/org/commcare/cases/test/CaseParseAndReadTest.java
+++ b/tests/test/org/commcare/cases/test/CaseParseAndReadTest.java
@@ -1,8 +1,8 @@
 package org.commcare.cases.test;
 
-import org.commcare.cases.CaseTestUtils;
-import org.commcare.test.utils.TestInstanceInitializer;
-import org.commcare.test.utils.XmlComparator;
+import org.commcare.test.utilities.CaseTestUtils;
+import org.commcare.test.utilities.TestInstanceInitializer;
+import org.commcare.test.utilities.XmlComparator;
 import org.commcare.util.mocks.MockDataUtils;
 import org.commcare.util.mocks.MockUserDataSandbox;
 import org.javarosa.core.io.StreamsUtil;

--- a/tests/test/org/commcare/cases/test/CaseXPathQueryTest.java
+++ b/tests/test/org/commcare/cases/test/CaseXPathQueryTest.java
@@ -1,6 +1,6 @@
 package org.commcare.cases.test;
 
-import org.commcare.cases.CaseTestUtils;
+import org.commcare.test.utilities.CaseTestUtils;
 import org.commcare.util.mocks.MockDataUtils;
 import org.commcare.util.mocks.MockUserDataSandbox;
 import org.javarosa.core.model.condition.EvaluationContext;

--- a/tests/test/org/commcare/cases/util/test/CasePurgeFilterTests.java
+++ b/tests/test/org/commcare/cases/util/test/CasePurgeFilterTests.java
@@ -1,4 +1,4 @@
-package org.commcare.util.test;
+package org.commcare.cases.util.test;
 
 import org.commcare.cases.model.Case;
 import org.commcare.cases.model.CaseIndex;

--- a/tests/test/org/commcare/cases/util/test/CasePurgeIntegrationTest.java
+++ b/tests/test/org/commcare/cases/util/test/CasePurgeIntegrationTest.java
@@ -1,4 +1,4 @@
-package org.commcare.util.test;
+package org.commcare.cases.util.test;
 
 import org.commcare.cases.util.CasePurgeFilter;
 import org.commcare.util.mocks.MockDataUtils;

--- a/tests/test/org/commcare/test/utilities/CaseTestUtils.java
+++ b/tests/test/org/commcare/test/utilities/CaseTestUtils.java
@@ -1,4 +1,4 @@
-package org.commcare.cases;
+package org.commcare.test.utilities;
 
 import org.javarosa.core.model.condition.EvaluationContext;
 import org.javarosa.xpath.XPathParseTool;

--- a/tests/test/org/commcare/test/utilities/MockApp.java
+++ b/tests/test/org/commcare/test/utilities/MockApp.java
@@ -1,15 +1,13 @@
-package org.commcare.test.utils;
+package org.commcare.test.utilities;
 
 import java.lang.IllegalArgumentException;
 
-import org.commcare.resources.model.UnresolvedResourceException;
 import org.commcare.util.CommCareConfigEngine;
 import org.commcare.util.mocks.LivePrototypeFactory;
 import org.commcare.util.mocks.MockDataUtils;
 import org.commcare.util.mocks.MockUserDataSandbox;
 import org.commcare.util.mocks.SessionWrapper;
 import org.javarosa.core.util.externalizable.PrototypeFactory;
-import org.javarosa.xml.util.UnfullfilledRequirementsException;
 
 /**
  * A mock app is a quick test wrapper that makes it easy to start playing with a live instance

--- a/tests/test/org/commcare/test/utilities/PersistableSandbox.java
+++ b/tests/test/org/commcare/test/utilities/PersistableSandbox.java
@@ -1,4 +1,4 @@
-package org.commcare.test.utils;
+package org.commcare.test.utilities;
 
 import org.commcare.util.mocks.LivePrototypeFactory;
 import org.javarosa.core.util.externalizable.DeserializationException;

--- a/tests/test/org/commcare/test/utilities/TemplateStructureTest.java
+++ b/tests/test/org/commcare/test/utilities/TemplateStructureTest.java
@@ -1,9 +1,8 @@
-package org.commcare.test.utils.test;
+package org.commcare.test.utilities;
 
 import org.commcare.util.mocks.SessionWrapper;
 import org.junit.Assert;
 
-import org.commcare.test.utils.MockApp;
 import org.commcare.util.SessionFrame;
 import org.junit.Before;
 import org.junit.Test;

--- a/tests/test/org/commcare/test/utilities/TestHelpers.java
+++ b/tests/test/org/commcare/test/utilities/TestHelpers.java
@@ -1,4 +1,4 @@
-package org.commcare.test.utils;
+package org.commcare.test.utilities;
 
 import org.junit.Assert;
 

--- a/tests/test/org/commcare/test/utilities/TestInstanceInitializer.java
+++ b/tests/test/org/commcare/test/utilities/TestInstanceInitializer.java
@@ -1,4 +1,4 @@
-package org.commcare.test.utils;
+package org.commcare.test.utilities;
 
 import org.commcare.cases.instance.CaseInstanceTreeElement;
 import org.commcare.util.mocks.MockUserDataSandbox;

--- a/tests/test/org/commcare/test/utilities/XmlComparator.java
+++ b/tests/test/org/commcare/test/utilities/XmlComparator.java
@@ -1,4 +1,4 @@
-package org.commcare.test.utils;
+package org.commcare.test.utilities;
 
 import org.kxml2.io.KXmlParser;
 import org.kxml2.kdom.Document;

--- a/tests/test/org/commcare/util/reference/test/JavaResourceReferenceTest.java
+++ b/tests/test/org/commcare/util/reference/test/JavaResourceReferenceTest.java
@@ -1,14 +1,12 @@
-package org.commcare.cases.reference.test;
+package org.commcare.util.reference.test;
 
-import org.commcare.test.utils.TestHelpers;
-import org.javarosa.core.io.StreamsUtil;
+import org.commcare.test.utilities.TestHelpers;
 import org.junit.Assert;
 
 import org.commcare.util.reference.JavaResourceReference;
 import org.commcare.util.reference.JavaResourceRoot;
 import org.javarosa.core.reference.Reference;
 import org.javarosa.core.reference.ReferenceManager;
-import org.junit.Before;
 import org.junit.Test;
 
 import java.io.InputStream;


### PR DESCRIPTION
So there are 4 sub-directories that we use in commcare: application, backend, cases, and util. However, within those 4 directories, we use many of the same package names, making the current organization of our tests directory confusing, because 2 test files in the same package do not necessarily correspond to 2 files in the same part of the code base. (It is worth nothing that currently, the 'cases' and 'util' directories both include their own subdirectory name in their package names (i.e. org.commcare.cases.xxx, and org.commcare.util.xxx), while 'application' and 'backend' do not (i.e. just org.commcare.xxx). This is something we likely want to fix separately).

This PR reorganizes the hierarchy and package naming of the tests directory to make it much clearer where the files that they test are located in the codebase. The reorganized tests directory adheres to the following logic/rules:
-If a test file contains tests for a file that is in subdirectory AAA, and in package org.commcare.XXX, the test file is now in package org.commcare.AAA.XXX.test (this is true for test files corresponding to the 'application' and 'backend' sub-directories as well, even though the package naming in the regular codebase does not yet include the AAA part)
-If a test file does not correspond directly to a specific file in the codebase, it is in package org.commcare.AAA.test, where AAA is the sub-directory to which the tests are related.
-ALL test utility/helper files are in the package org.commcare.test.utilities (NOT to be confused with the test package org.commcare.util, which is the package for all test files of the 'util' sub-directory).

...I hope that was a reasonable way of explaining it. 