### PR TITLE
Fixed issue with session data getting double loaded from the stack

### DIFF
--- a/backend/src/org/commcare/util/CommCareSession.java
+++ b/backend/src/org/commcare/util/CommCareSession.java
@@ -405,9 +405,16 @@ public class CommCareSession {
 
         for (StackFrameStep step : frame.getSteps()) {
             if (step.getType() == SessionFrame.STATE_DATUM_VAL) {
-                TreeElement datum = new TreeElement(step.getId());
-                datum.setValue(new UncastData(step.getValue()));
-                sessionData.addChild(datum);
+
+                Vector<TreeElement> matchingElements = sessionData.getChildrenWithName(step.getId());
+
+                if(matchingElements.size() > 0) {
+                    matchingElements.elementAt(0).setValue(new UncastData(step.getValue()));
+                } else {
+                    TreeElement datum = new TreeElement(step.getId());
+                    datum.setValue(new UncastData(step.getValue()));
+                    sessionData.addChild(datum);
+                }
             }
         }
 

--- a/tests/resources/complex_stack/form_placeholder.xml
+++ b/tests/resources/complex_stack/form_placeholder.xml
@@ -1,0 +1,17 @@
+<h:html xmlns:h="http://www.w3.org/1999/xhtml" xmlns:orx="http://openrosa.org/jr/xforms" xmlns="http://www.w3.org/2002/xforms" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:jr="http://openrosa.org/javarosa" xmlns:vellum="http://commcarehq.org/xforms/vellum">
+	<h:head>
+		<h:title>Placeholder Form</h:title>
+		<model>
+			<instance>
+				<data xmlns:jrm="http://dev.commcarehq.org/jr/xforms" xmlns="http://commcarehq.org/test/placeholder" uiVersion="1" version="1" name="Placeholder">
+					<item/>
+				</data>
+			</instance>
+		</model>
+	</h:head>
+	<h:body>
+		<input ref="/data/item">
+			<label>placeholder</label>
+		</input>
+	</h:body>
+</h:html>

--- a/tests/resources/complex_stack/profile.ccpr
+++ b/tests/resources/complex_stack/profile.ccpr
@@ -1,0 +1,14 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<profile version="1"
+         requiredMajor="2"
+         requiredMinor="22"
+         uniqueid="id"
+         update=""
+         name="trivial_test_resources"
+         descriptor="Profile">
+
+
+    <suite><resource id="suite" version="1">
+            <location authority="local">./suite.xml</location>
+    </resource></suite>
+</profile>

--- a/tests/resources/complex_stack/suite.xml
+++ b/tests/resources/complex_stack/suite.xml
@@ -1,0 +1,85 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<suite version="1" descriptor="Suite File">
+  <xform>
+    <resource id="546d5695ad31d060faac835fea2bc436810c81f9" version="1" descriptor="Form: Placeholder">
+      <location authority="local">./form_placeholder.xml</location>
+    </resource>
+  </xform>
+
+  <detail id="m0_case_short">
+    <title>
+      <text>Case List</text>
+    </title>
+      <action>
+          <display>
+              <text>Jump to Menu 2 Form 1</text>
+          </display>
+          <stack>
+              <push>
+                  <command value="'m1-f0'"/>
+                  <datum id="calculated_data" value="'new'"/>
+              </push>
+          </stack>
+      </action>
+
+      <field>
+      <header>
+        <text>Name</text>
+      </header>
+      <template>
+        <text>
+          <xpath function="case_name"/>
+        </text>
+      </template>
+      <sort type="string" order="1" direction="ascending">
+        <text>
+          <xpath function="case_name"/>
+        </text>
+      </sort>
+    </field>
+  </detail>
+  <detail id="m0_case_long">
+    <title>
+      <text>Case Detail</text>
+    </title>
+    <field>
+      <header>
+        <text>Name</text>
+      </header>
+      <template>
+        <text>
+          <xpath function="case_name"/>
+        </text>
+      </template>
+    </field>
+  </detail>
+
+  <entry>
+    <form>http://commcarehq.org/test/placeholder_destination</form>
+    <instance id="session" src="jr://instance/session"/>
+    <command id="m1-f0">
+      <text>Form</text>
+    </command>
+  </entry>
+
+  <entry>
+    <form>http://commcarehq.org/test/placeholder</form>
+    <command id="m0-f0">
+      <text>Form</text>
+    </command>
+    <instance id="casedb" src="jr://instance/casedb"/>
+    <session>
+      <datum id="calculated_data" function="'initial'"/>
+      <datum id="case_id" nodeset="instance('casedb')/casedb/case[@case_type='test_case'][@status='open']" value="./@case_id" detail-select="m0_case_short" detail-confirm="m0_case_long"/>
+    </session>
+  </entry>
+  <menu id="m0">
+    <text>Menu 1</text>
+    <command id="m0-f0"/>
+  </menu>
+
+    <menu id="m1">
+        <text>Menu 2</text>
+        <command id="m1-f0"/>
+    </menu>
+</suite>

--- a/tests/resources/complex_stack/user_restore.xml
+++ b/tests/resources/complex_stack/user_restore.xml
@@ -1,0 +1,21 @@
+<OpenRosaResponse>
+	<message nature="ota_restore_success">Successfully restored account test!</message>
+	<Sync xmlns="http://commcarehq.org/sync">
+		<restore_id>sync_token</restore_id>
+	</Sync>
+	<Registration xmlns="http://openrosa.org/user/registration">
+		<username>test</username>
+		<password>sha1$60441$53cf77c2ac3608a944db96af177a6dfe1579e4ba</password>
+		<uuid>test_uuid</uuid>
+		<date>2012-04-30</date>
+	</Registration>
+	<case case_id="case_one"
+		date_modified="2014-08-04T21:09:07.000000Z" user_id="test_uuid"
+		xmlns="http://commcarehq.org/case/transaction/v2">
+		<create>
+			<case_type>test_case</case_type>
+			<case_name>Test Case</case_name>
+			<owner_id>test_uuid</owner_id>
+		</create>
+	</case>
+</OpenRosaResponse>

--- a/tests/test/org/commcare/session/test/SessionStackTests.java
+++ b/tests/test/org/commcare/session/test/SessionStackTests.java
@@ -1,0 +1,66 @@
+package org.commcare.session.test;
+
+import org.commcare.suite.model.Action;
+import org.commcare.suite.model.StackOperation;
+import org.commcare.test.utilities.CaseTestUtils;
+import org.commcare.test.utilities.MockApp;
+import org.commcare.util.mocks.SessionWrapper;
+import org.javarosa.core.model.condition.EvaluationContext;
+import org.junit.Assert;
+
+import org.commcare.util.SessionFrame;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Vector;
+
+/**
+ * This is a super basic test just to make sure the test infrastructure is working correctly
+ * and to act as an example of how to build template app tests.
+ *
+ * Created by ctsims on 8/14/2015.
+ */
+public class SessionStackTests {
+    MockApp mApp;
+
+    @Before
+    public void init() throws Exception{
+        mApp = new MockApp("/complex_stack/");
+    }
+
+    @Test
+    public void testDoubleManagementAndOverlappingStack() throws Exception {
+        SessionWrapper session = mApp.getSession();
+        Assert.assertEquals(session.getNeededData(), SessionFrame.STATE_COMMAND_ID);
+
+        session.setCommand("m0");
+
+        Assert.assertEquals(session.getNeededData(), SessionFrame.STATE_DATUM_COMPUTED);
+
+        session.setComputedDatum();
+
+        Assert.assertEquals(session.getNeededData(), SessionFrame.STATE_DATUM_VAL);
+        Assert.assertEquals(session.getNeededDatum().getDataId(), "case_id");
+
+        Action dblManagement = session.getDetail(session.getNeededDatum().getShortDetail()).getCustomAction();
+
+        if(dblManagement == null) {
+            Assert.fail("Detail screen stack action was missing from app!");
+        }
+
+        session.executeStackOperations(dblManagement.getStackOperations(), session.getEvaluationContext());
+
+        if(session.getNeededData() != null) {
+            Assert.fail("After executing stack frame steps, session should be redirected");
+        }
+
+        Assert.assertEquals(session.getForm(), "http://commcarehq.org/test/placeholder_destination");
+
+        EvaluationContext ec = session.getEvaluationContext();
+
+        CaseTestUtils.xpathEvalAndCompare(ec,"count(instance('session')/session/data/calculated_data)", 1);
+
+        CaseTestUtils.xpathEvalAndCompare(ec,"instance('session')/session/data/calculated_data", "new");
+    }
+
+}

--- a/tests/test/org/commcare/test/utilities/MockApp.java
+++ b/tests/test/org/commcare/test/utilities/MockApp.java
@@ -7,6 +7,8 @@ import org.commcare.util.mocks.LivePrototypeFactory;
 import org.commcare.util.mocks.MockDataUtils;
 import org.commcare.util.mocks.MockUserDataSandbox;
 import org.commcare.util.mocks.SessionWrapper;
+import org.commcare.util.mocks.User;
+import org.javarosa.core.services.storage.IStorageIterator;
 import org.javarosa.core.util.externalizable.PrototypeFactory;
 
 /**
@@ -42,6 +44,12 @@ public class MockApp {
         mEngine.installAppFromReference("jr://resource" + resourcePath + "profile.ccpr");
         mEngine.initEnvironment();
         MockDataUtils.parseIntoSandbox(this.getClass().getResourceAsStream(resourcePath + "user_restore.xml"), mSandbox);
+
+        //If we parsed in a user, arbitrarily log one in.
+        for(IStorageIterator<User> iterator = mSandbox.getUserStorage().iterate(); iterator.hasMore();) {
+            mSandbox.setLoggedInUser(iterator.nextRecord());
+            break;
+        }
 
         mSessionWrapper = new SessionWrapper(mEngine.getPlatform(), mSandbox);
     }


### PR DESCRIPTION
From 
http://manage.dimagi.com/default.asp?178635

If the session has two datums on it that conflict on the definition of a value, the session was getting loaded with both.