### PR TITLE
Add EntitySubnodeDetailSubscreen

### DIFF
--- a/util/src/org/commcare/util/cli/EntityListSubscreen.java
+++ b/util/src/org/commcare/util/cli/EntityListSubscreen.java
@@ -19,9 +19,9 @@ public class EntityListSubscreen extends Subscreen<EntityScreen> {
 
     private final int SCREEN_WIDTH = 100;
 
-    private TreeReference[] mChoices;
-    private String[] rows;
-    private String mHeader;
+    protected TreeReference[] mChoices;
+    protected String[] rows;
+    protected String mHeader;
 
     public EntityListSubscreen(Detail shortDetail, Vector<TreeReference> references, EvaluationContext context) throws CommCareSessionException {
         mHeader = this.createHeader(shortDetail, context);
@@ -111,9 +111,12 @@ public class EntityListSubscreen extends Subscreen<EntityScreen> {
         try {
             int i = Integer.parseInt(input);
 
-            host.setHighlightedEntity(this.mChoices[i]);
+            if (i >= 0 && i < mChoices.length) {
+                host.setHighlightedEntity(this.mChoices[i]);
+                return !host.setCurrentScreenToDetail();
+            }
 
-            return !host.setCurrentScreenToDetail();
+            return false;
         } catch (NumberFormatException e) {
             //This will result in things just executing again, which is fine.
         }

--- a/util/src/org/commcare/util/cli/EntityScreen.java
+++ b/util/src/org/commcare/util/cli/EntityScreen.java
@@ -120,7 +120,7 @@ public class EntityScreen extends CompoundScreenHost {
         TreeReference detailNodeset = this.mLongDetailList[index].getNodeset();
         if (detailNodeset != null) {
             TreeReference contextualizedNodeset = detailNodeset.contextualize(this.mCurrentSelection);
-            this.mCurrentScreen = new EntityListSubscreen(this.mLongDetailList[index], subContext.expandReference(contextualizedNodeset), subContext);
+            this.mCurrentScreen = new EntitySubnodeDetailSubscreen(this.mLongDetailList[index], subContext, contextualizedNodeset);
         }
         else {
             this.mCurrentScreen = new EntityDetailSubscreen(index, this.mLongDetailList[index], subContext, getDetailListTitles(subContext));

--- a/util/src/org/commcare/util/cli/EntitySubnodeDetailSubscreen.java
+++ b/util/src/org/commcare/util/cli/EntitySubnodeDetailSubscreen.java
@@ -1,0 +1,36 @@
+package org.commcare.util.cli;
+
+import org.commcare.suite.model.Detail;
+import org.javarosa.core.model.condition.EvaluationContext;
+import org.javarosa.core.model.instance.TreeReference;
+
+import java.io.PrintStream;
+import java.util.Vector;
+
+/**
+ * Created by jschweers on 9/10/2015.
+ */
+public class EntitySubnodeDetailSubscreen extends EntityListSubscreen {
+    public EntitySubnodeDetailSubscreen(Detail shortDetail, EvaluationContext context, TreeReference contextualizedNodeset) throws CommCareSessionException {
+        super(shortDetail, context.expandReference(contextualizedNodeset), context);
+    }
+
+    @Override
+    public void prompt(PrintStream out) {
+
+        int maxLength = String.valueOf(mChoices.length).length();
+        out.println(CliUtils.pad("", maxLength + 1) + mHeader);
+        out.println("==============================================================================================");
+
+        for (int i = 0; i < mChoices.length; ++i) {
+            out.println(rows[i]);
+        }
+
+        out.println("Press enter to select this case");
+    }
+
+    @Override
+    public boolean handleInputAndUpdateHost(String input, EntityScreen host) throws CommCareSessionException {
+        return true;
+    }
+}


### PR DESCRIPTION
Opening for feedback.

@ctsims This no longer crashes, but after you confirm on the detail screen, it brings up an empty menu screen instead of going back home - the command should be null/root, but it's still m0. I'm having a pretty difficult time debugging the session changes, am curious if you see anything obviously wrong here. If not, I'll dig more into sessions.