### PR TITLE
Hotfix: make getNeededDatum() robust to out of order data on stack

### DIFF
--- a/backend/src/org/commcare/util/CommCareSession.java
+++ b/backend/src/org/commcare/util/CommCareSession.java
@@ -244,15 +244,21 @@ public class CommCareSession {
      * @return A session datum definition if one is pending. Null otherwise.
      */
     public SessionDatum getNeededDatum(Entry entry) {
-        int nextVal = getData().size();
-        //If we've already retrieved all data needed, return null.
-        if (nextVal >= entry.getSessionDataReqs().size()) {
-            return null;
-        }
+        return getFirstMissingDatum(getData(), entry.getSessionDataReqs());
+    }
 
-        //Otherwise retrieve the needed value
-        SessionDatum datum = entry.getSessionDataReqs().elementAt(nextVal);
-        return datum;
+    /**
+     * Return the first SessionDatum that is in allDatumsNeeded, but is not represented in
+     * datumsCollectedSoFar
+     */
+    private SessionDatum getFirstMissingDatum(OrderedHashtable datumsCollectedSoFar,
+                                              Vector<SessionDatum> allDatumsNeeded) {
+        for (SessionDatum datum : allDatumsNeeded) {
+            if (!datumsCollectedSoFar.containsKey(datum.getDataId())) {
+                return datum;
+            }
+        }
+        return null;
     }
 
     public Detail getDetail(String id) {

--- a/tests/resources/session-tests-template/suite.xml
+++ b/tests/resources/session-tests-template/suite.xml
@@ -70,6 +70,18 @@
       <datum id="case_id" nodeset="instance('casedb')/casedb/case[@case_type='pregnancy'][@status='open']" value="./@case_id" detail-select="m0_case_short" detail-confirm="m0_case_long"/>
     </session>
   </entry>
+    <entry>
+        <form>http://commcarehq.org/test/placeholder</form>
+        <command id="m0-f3">
+            <text>Module 0 Form 3</text>
+        </command>
+        <instance id="casedb" src="jr://instance/casedb"/>
+        <session>
+            <datum id="case_id" nodeset="instance('casedb')/casedb/case[@case_type='pregnancy'][@status='open']" value="./@case_id" detail-select="m2_case_short" detail-confirm="m2_case_long"/>
+            <datum id="case_id_new_visit_0" function="uuid()"/>
+            <datum id="usercase_id" function="uuid()"/>
+        </session>
+    </entry>
   <entry>
     <form>http://openrosa.org/formdesigner/C03AA95B-48CF-4229-BBFB-CC607EE847B7</form>
     <command id="m1-f0">

--- a/tests/test/org/commcare/backend/util/test/SessionStackTests.java
+++ b/tests/test/org/commcare/backend/util/test/SessionStackTests.java
@@ -1,7 +1,6 @@
 package org.commcare.backend.util.test;
 
 import org.commcare.suite.model.Action;
-import org.commcare.suite.model.StackOperation;
 import org.commcare.test.utilities.CaseTestUtils;
 import org.commcare.test.utilities.MockApp;
 import org.commcare.util.mocks.SessionWrapper;
@@ -9,10 +8,7 @@ import org.javarosa.core.model.condition.EvaluationContext;
 import org.junit.Assert;
 
 import org.commcare.util.SessionFrame;
-import org.junit.Before;
 import org.junit.Test;
-
-import java.util.Vector;
 
 /**
  * This is a super basic test just to make sure the test infrastructure is working correctly
@@ -23,24 +19,21 @@ import java.util.Vector;
 public class SessionStackTests {
     MockApp mApp;
 
-    @Before
-    public void init() throws Exception{
-        mApp = new MockApp("/complex_stack/");
-    }
-
     @Test
     public void testDoubleManagementAndOverlappingStack() throws Exception {
+        mApp = new MockApp("/complex_stack/");
         SessionWrapper session = mApp.getSession();
-        Assert.assertEquals(session.getNeededData(), SessionFrame.STATE_COMMAND_ID);
+
+        Assert.assertEquals(SessionFrame.STATE_COMMAND_ID, session.getNeededData());
 
         session.setCommand("m0");
 
-        Assert.assertEquals(session.getNeededData(), SessionFrame.STATE_DATUM_COMPUTED);
+        Assert.assertEquals(SessionFrame.STATE_DATUM_COMPUTED, session.getNeededData());
 
         session.setComputedDatum();
 
-        Assert.assertEquals(session.getNeededData(), SessionFrame.STATE_DATUM_VAL);
-        Assert.assertEquals(session.getNeededDatum().getDataId(), "case_id");
+        Assert.assertEquals(SessionFrame.STATE_DATUM_VAL, session.getNeededData());
+        Assert.assertEquals("case_id", session.getNeededDatum().getDataId());
 
         Action dblManagement = session.getDetail(session.getNeededDatum().getShortDetail()).getCustomAction();
 
@@ -54,7 +47,7 @@ public class SessionStackTests {
             Assert.fail("After executing stack frame steps, session should be redirected");
         }
 
-        Assert.assertEquals(session.getForm(), "http://commcarehq.org/test/placeholder_destination");
+        Assert.assertEquals("http://commcarehq.org/test/placeholder_destination", session.getForm());
 
         EvaluationContext ec = session.getEvaluationContext();
 
@@ -65,14 +58,16 @@ public class SessionStackTests {
 
     @Test
     public void testViewNav() throws Exception {
+        mApp = new MockApp("/complex_stack/");
         SessionWrapper session = mApp.getSession();
-        Assert.assertEquals(session.getNeededData(), SessionFrame.STATE_COMMAND_ID);
+
+        Assert.assertEquals(SessionFrame.STATE_COMMAND_ID, session.getNeededData());
 
         session.setCommand("m3-f0");
 
-        Assert.assertEquals(session.getNeededData(), SessionFrame.STATE_DATUM_VAL);
+        Assert.assertEquals(SessionFrame.STATE_DATUM_VAL, session.getNeededData());
 
-        Assert.assertEquals(session.getNeededDatum().getDataId(), "case_id_to_send");
+        Assert.assertEquals("case_id_to_send", session.getNeededDatum().getDataId());
 
         Assert.assertFalse("Session incorrectly determined a view command", session.isViewCommand(session.getCommand()));
 
@@ -80,7 +75,7 @@ public class SessionStackTests {
 
         session.finishExecuteAndPop(session.getEvaluationContext());
 
-        Assert.assertEquals(session.getCommand(), "m2");
+        Assert.assertEquals("m2", session.getCommand());
 
         CaseTestUtils.xpathEvalAndCompare(session.getEvaluationContext(),
                 "instance('session')/session/data/case_id", "case_one");
@@ -88,21 +83,51 @@ public class SessionStackTests {
         CaseTestUtils.xpathEvalAndCompare(session.getEvaluationContext(),
                 "count(instance('session')/session/data/case_id_to_send)", "0");
 
-        Assert.assertEquals(session.getNeededData(), SessionFrame.STATE_COMMAND_ID);
+        Assert.assertEquals(SessionFrame.STATE_COMMAND_ID, session.getNeededData());
     }
 
     @Test
     public void testViewNonNav() throws Exception {
+        mApp = new MockApp("/complex_stack/");
         SessionWrapper session = mApp.getSession();
-        Assert.assertEquals(session.getNeededData(), SessionFrame.STATE_COMMAND_ID);
+
+        Assert.assertEquals(SessionFrame.STATE_COMMAND_ID, session.getNeededData());
 
         session.setCommand("m4-f0");
 
-        Assert.assertEquals(session.getNeededData(), SessionFrame.STATE_DATUM_VAL);
+        Assert.assertEquals(SessionFrame.STATE_DATUM_VAL, session.getNeededData());
 
-        Assert.assertEquals(session.getNeededDatum().getDataId(), "case_id_to_view");
+        Assert.assertEquals("case_id_to_view", session.getNeededDatum().getDataId());
 
         Assert.assertTrue("Session incorrectly tagged a view command", session.isViewCommand(session.getCommand()));
+    }
+
+    @Test
+    public void testOutOfOrderStack() throws Exception {
+        mApp = new MockApp("/session-tests-template/");
+        SessionWrapper session = mApp.getSession();
+
+        // Select a form that has 3 datum requirements to enter (in order from suite.xml: case_id,
+        // case_id_new_visit_0, usercase_id)
+        Assert.assertEquals(SessionFrame.STATE_COMMAND_ID, session.getNeededData());
+        session.setCommand("m0");
+
+        Assert.assertEquals(SessionFrame.STATE_COMMAND_ID, session.getNeededData());
+        session.setCommand("m0-f3");
+
+        // Set 2 of the 3 needed datums, but not in order (1st and 3rd)
+        session.setDatum("case_id", "case_id_value");
+        session.setDatum("usercase_id", "usercase_id_value");
+
+        // Session should now need the case_id_new_visit_0, which is a computed datum
+        Assert.assertEquals(SessionFrame.STATE_DATUM_COMPUTED, session.getNeededData());
+
+        // The key of the needed datum should be "case_id_new_visit_0"
+        Assert.assertEquals("case_id_new_visit_0", session.getNeededDatum().getDataId());
+
+        // Add the needed datum to the stack and confirm that the session is now ready to proceed
+        session.setDatum("case_id_new_visit_0", "visit_id_value");
+        Assert.assertEquals(null, session.getNeededData());
     }
 
 }


### PR DESCRIPTION
fix for http://manage.dimagi.com/default.asp?183023

Similar fix going into master: https://github.com/dimagi/commcare/pull/169