### PR TITLE
Session stack fix part 2

### DIFF
--- a/backend/src/org/commcare/session/CommCareSession.java
+++ b/backend/src/org/commcare/session/CommCareSession.java
@@ -72,7 +72,7 @@ public class CommCareSession {
         this.platform = platform;
         collectedDatums = new OrderedHashtable();
         this.frame = new SessionFrame();
-        this.frameStack = new Stack<>();
+        this.frameStack = new Stack<SessionFrame>();
     }
 
     public Vector<Entry> getEntriesForCommand(String commandId) {

--- a/backend/src/org/commcare/session/CommCareSession.java
+++ b/backend/src/org/commcare/session/CommCareSession.java
@@ -72,13 +72,19 @@ public class CommCareSession {
         this.platform = platform;
         collectedDatums = new OrderedHashtable();
         this.frame = new SessionFrame();
-        this.frameStack = new Stack<SessionFrame>();
+        this.frameStack = new Stack<>();
     }
 
     public Vector<Entry> getEntriesForCommand(String commandId) {
         return this.getEntriesForCommand(commandId, new OrderedHashtable());
     }
 
+    /**
+     * @param commandId the current command id
+     * @param data all of the datums already on the stack
+     * @return A list of all of the form entry actions that are possible with the given commandId
+     * and the given list of already-collected datums
+     */
     public Vector<Entry> getEntriesForCommand(String commandId, OrderedHashtable data) {
         Hashtable<String, Entry> map = platform.getMenuMap();
         Menu menu = null;
@@ -86,7 +92,7 @@ public class CommCareSession {
         top:
         for (Suite s : platform.getInstalledSuites()) {
             for (Menu m : s.getMenus()) {
-                //We need to see if everything in this menu can be matched
+                // We need to see if everything in this menu can be matched
                 if (commandId.equals(m.getId())) {
                     menu = m;
                     break top;
@@ -151,22 +157,20 @@ public class CommCareSession {
             return SessionFrame.STATE_COMMAND_ID;
         }
 
-        Vector<Entry> entries = getEntriesForCommand(this.getCommand(), this.getData());
+        Vector<Entry> possibleEntries = getEntriesForCommand(this.getCommand(), this.getData());
 
         //Get data. Checking first to see if the relevant key is needed by all entries
 
         String needDatum = null;
         String nextKey = null;
-        for (Entry e : entries) {
+        for (Entry e : possibleEntries) {
 
-            //TODO: With the introduction of <action>s there's no way we can keep pretending it's ok to just use this length
-            //to make sure things are fine. We need to comprehensively address matching these as sets.
-            if (e.getSessionDataReqs().size() > this.getData().size()) {
-                SessionDatum datum = e.getSessionDataReqs().elementAt(this.getData().size());
-                String needed = datum.getDataId();
+            SessionDatum datumNeededForThisEntry = getFirstMissingDatum(this.getData(), e.getSessionDataReqs());
+            if (datumNeededForThisEntry != null) {
+                String needed = datumNeededForThisEntry.getDataId();
                 if (nextKey == null) {
                     nextKey = needed;
-                    if (datum.getNodeset() != null) {
+                    if (datumNeededForThisEntry.getNodeset() != null) {
                         needDatum = SessionFrame.STATE_DATUM_VAL;
                     } else {
                         needDatum = SessionFrame.STATE_DATUM_COMPUTED;
@@ -180,18 +184,19 @@ public class CommCareSession {
                 }
             }
 
-            //If we made it here, we either don't need more data or don't need
-            //consistent data for the remaining options
+            // If we made it here, we either don't need more data or don't need
+            // consistent data for the remaining options
             needDatum = null;
             break;
         }
+
         if (needDatum != null) {
             return needDatum;
         }
 
         //the only other thing we can need is a form command. If there's still
         //more than one applicable entry, we need to keep going
-        if (entries.size() > 1 || !entries.elementAt(0).getCommandId().equals(this.getCommand())) {
+        if (possibleEntries.size() > 1 || !possibleEntries.elementAt(0).getCommandId().equals(this.getCommand())) {
             return SessionFrame.STATE_COMMAND_ID;
         } else {
             return null;

--- a/tests/test/org/commcare/backend/session/test/SessionStackTests.java
+++ b/tests/test/org/commcare/backend/session/test/SessionStackTests.java
@@ -153,11 +153,11 @@ public class SessionStackTests {
         Assert.assertEquals(SessionFrame.STATE_DATUM_VAL, session.getNeededData());
 
         // The key of the needed datum should be "case_id"
-        /*Assert.assertEquals("case_id", session.getNeededDatum().getDataId());
+        Assert.assertEquals("case_id", session.getNeededDatum().getDataId());
 
         // Add the needed datum to the stack and confirm that the session is now ready to proceed
         session.setDatum("case_id", "case_id_value");
-        Assert.assertEquals(null, session.getNeededData());*/
+        Assert.assertEquals(null, session.getNeededData());
     }
 
     @Test

--- a/tests/test/org/commcare/backend/session/test/SessionStackTests.java
+++ b/tests/test/org/commcare/backend/session/test/SessionStackTests.java
@@ -132,6 +132,35 @@ public class SessionStackTests {
     }
 
     @Test
+    public void testOutOfOrderStackComplex() throws Exception {
+        mApp = new MockApp("/session-tests-template/");
+        SessionWrapper session = mApp.getSession();
+
+        // Select a form that has 3 datum requirements to enter (in order from suite.xml: case_id,
+        // case_id_new_visit_0, usercase_id)
+        Assert.assertEquals(SessionFrame.STATE_COMMAND_ID, session.getNeededData());
+        session.setCommand("m0");
+
+        Assert.assertEquals(SessionFrame.STATE_COMMAND_ID, session.getNeededData());
+        session.setCommand("m0-f3");
+
+        // Set 2 of the 3 needed datums, so that the datum that is actually still needed (case_id)
+        // is NOT a computed value, but the "last" needed datum is a computed value
+        session.setDatum("case_id_new_visit_0", "visit_id_value");
+        session.setDatum("usercase_id", "usercase_id_value");
+
+        // Session should now see that it needs a normal datum val (NOT a computed val)
+        Assert.assertEquals(SessionFrame.STATE_DATUM_VAL, session.getNeededData());
+
+        // The key of the needed datum should be "case_id"
+        /*Assert.assertEquals("case_id", session.getNeededDatum().getDataId());
+
+        // Add the needed datum to the stack and confirm that the session is now ready to proceed
+        session.setDatum("case_id", "case_id_value");
+        Assert.assertEquals(null, session.getNeededData());*/
+    }
+
+    @Test
     public void testUnnecessaryDataOnStack() throws Exception {
         mApp = new MockApp("/session-tests-template/");
         SessionWrapper session = mApp.getSession();

--- a/tests/test/org/commcare/backend/session/test/SessionStackTests.java
+++ b/tests/test/org/commcare/backend/session/test/SessionStackTests.java
@@ -184,20 +184,19 @@ public class SessionStackTests {
         // and still sees itself as needing each of the datums defined for this form, in the correct
         // order
 
-        //TODO: Fix faulty logic in CommCareSession.getNeededData() so that these assertions pass
-        //Assert.assertEquals(SessionFrame.STATE_DATUM_VAL, session.getNeededData());
-        //Assert.assertEquals("case_id", session.getNeededDatum().getDataId());
+        Assert.assertEquals(SessionFrame.STATE_DATUM_VAL, session.getNeededData());
+        Assert.assertEquals("case_id", session.getNeededDatum().getDataId());
 
-        //session.setDatum("case_id", "case_id_value");
-        //Assert.assertEquals(SessionFrame.STATE_DATUM_COMPUTED, session.getNeededData());
-        //Assert.assertEquals("case_id_new_visit_0", session.getNeededDatum().getDataId());
+        session.setDatum("case_id", "case_id_value");
+        Assert.assertEquals(SessionFrame.STATE_DATUM_COMPUTED, session.getNeededData());
+        Assert.assertEquals("case_id_new_visit_0", session.getNeededDatum().getDataId());
 
-        //session.setDatum("case_id_new_visit_0", "visit_id_value");
-        //Assert.assertEquals(SessionFrame.STATE_DATUM_COMPUTED, session.getNeededData());
-        //Assert.assertEquals("usercase_id", session.getNeededDatum().getDataId());
+        session.setDatum("case_id_new_visit_0", "visit_id_value");
+        Assert.assertEquals(SessionFrame.STATE_DATUM_COMPUTED, session.getNeededData());
+        Assert.assertEquals("usercase_id", session.getNeededDatum().getDataId());
 
-        //session.setDatum("usercase_id", "usercase_id_value");
-        //Assert.assertEquals(null, session.getNeededData());
+        session.setDatum("usercase_id", "usercase_id_value");
+        Assert.assertEquals(null, session.getNeededData());
     }
 
 }


### PR DESCRIPTION
Fixed getNeededData() to do a proper check for what the next datum needed by an entry is -- makes the stack robust to more complicated versions of the datum entries on the stack being out of order, and to having bogus data on the stack.