### PR TITLE
Don't log when adding a resource that is already present

### DIFF
--- a/backend/src/org/commcare/resources/model/ResourceTable.java
+++ b/backend/src/org/commcare/resources/model/ResourceTable.java
@@ -144,9 +144,7 @@ public class ResourceTable {
     public void addResource(Resource resource, int status) {
         if (resourceDoesntExist(resource)) {
             addResourceInner(resource, status);
-        } else {
-            Logger.log("Resource", "Trying to add an already existing resource: " + resource.getResourceId());
-        }
+        } 
     }
     private boolean resourceDoesntExist(Resource resource) {
         return storage.getIDsForValue(Resource.META_INDEX_RESOURCE_ID, resource.getResourceId()).size() == 0;


### PR DESCRIPTION
I added this log in when refactoring how apps were installed thinking it would be helpful. Turns out it creates a huge amount of clutter because this is fired all the time.