### PR TITLE
Fixed Extension Purge algorithm detals

### DIFF
--- a/tests/resources/case_relationship_tests.json
+++ b/tests/resources/case_relationship_tests.json
@@ -187,7 +187,35 @@
   ],
   "outcome":["d", "a","b"]
 }
-
-
-
+,{
+  "name":"Closed Extension",
+  "owned":["a"],
+  "closed":["b"],
+  "extensions":[
+    ["b","a"]
+  ],
+  "outcome":["a"]
+}
+,{
+  "name":"Closed Extension",
+  "owned":["a"],
+  "closed":["b"],
+  "extensions":[
+    ["c","b"]
+  ],
+  "subcases":[
+    ["a","b"]
+  ],
+  "outcome":["a", "b", "c"]
+}
+,{
+  "name":"Broken Extension Chain",
+  "owned":["a"],
+  "closed":["b"],
+  "extensions":[
+    ["b","a"],
+    ["c","b"]
+  ],
+  "outcome":["a"]
+}
 ]


### PR DESCRIPTION
Fixed extension case purge algorithm to reflect the proper traversal for closed extensions. Prevents extensions from staying available incorrectly if they are closed on inbound edges.