### PR TITLE
Expose CommCareInstanceInitializer setup to be easily overridden

### DIFF
--- a/core/org/commcare/core/process/CommCareInstanceInitializer.java
+++ b/core/org/commcare/core/process/CommCareInstanceInitializer.java
@@ -67,13 +67,7 @@ public class CommCareInstanceInitializer extends InstanceInitializationFactory {
             }
             return stockbase;
         } else if (ref.indexOf(CaseInstanceTreeElement.MODEL_NAME) != -1) {
-            if (casebase == null) {
-                casebase = new CaseInstanceTreeElement(instance.getBase(), mSandbox.getCaseStorage(), false);
-            } else {
-                //re-use the existing model if it exists.
-                casebase.rebase(instance.getBase());
-            }
-            return casebase;
+            return setupCaseData(instance);
         } else if (instance.getReference().indexOf("fixture") != -1) {
             //TODO: This is all just copied from J2ME code. that's pretty silly. unify that.
             String userId = "";
@@ -109,6 +103,16 @@ public class CommCareInstanceInitializer extends InstanceInitializationFactory {
             return root;
         }
         return null;
+    }
+
+    protected AbstractTreeElement setupCaseData(ExternalDataInstance instance) {
+        if (casebase == null) {
+            casebase = new CaseInstanceTreeElement(instance.getBase(), mSandbox.getCaseStorage(), false);
+        } else {
+            //re-use the existing model if it exists.
+            casebase.rebase(instance.getBase());
+        }
+        return casebase;
     }
 
     protected String getDeviceId(){


### PR DESCRIPTION
Expose case data instance setup code so that the android implementation can override it with custom logic.
  
cross-requested with https://github.com/dimagi/commcare-odk/pull/802