### PR TITLE
Use new fixture key for J2me storage

### DIFF
--- a/backend/src/org/commcare/xml/FixtureXmlParser.java
+++ b/backend/src/org/commcare/xml/FixtureXmlParser.java
@@ -106,7 +106,7 @@ public class FixtureXmlParser extends TransactionParser<FormInstance> {
         //the issue is that there are about 4 ways to set/override how this gets here
         //TODO: Fix this
         if (storage == null) {
-            storage = (IStorageUtilityIndexed)StorageManager.getStorage("fixture");
+            storage = (IStorageUtilityIndexed)StorageManager.getStorage(FormInstance.STORAGE_KEY);
         }
         return storage;
     }


### PR DESCRIPTION
Fix for http://manage.dimagi.com/default.asp?183837

We updated the key in the storage refactor and this wasn't reflected here