### PR TITLE
Fix for J2ME fixtures using new sandbox source

### DIFF
--- a/backend/src/org/commcare/xml/FixtureXmlParser.java
+++ b/backend/src/org/commcare/xml/FixtureXmlParser.java
@@ -106,7 +106,7 @@ public class FixtureXmlParser extends TransactionParser<FormInstance> {
         //the issue is that there are about 4 ways to set/override how this gets here
         //TODO: Fix this
         if (storage == null) {
-            storage = (IStorageUtilityIndexed)StorageManager.getStorage("fixture");
+            storage = (IStorageUtilityIndexed)StorageManager.getStorage(FormInstance.STORAGE_KEY);
         }
         return storage;
     }


### PR DESCRIPTION
Fixtures in j2me were broken after migrating the storage name to something consistent. Doesn't conflict with android, which loads its own fixture source.