### PR TITLE
Support for bar-color

### DIFF
--- a/backend/src/org/commcare/suite/model/graph/Graph.java
+++ b/backend/src/org/commcare/suite/model/graph/Graph.java
@@ -37,9 +37,9 @@ public class Graph implements Externalizable, DetailTemplate, Configurable {
     private Vector<Annotation> mAnnotations;
 
     public Graph() {
-        mSeries = new Vector<>();
-        mConfiguration = new Hashtable<>();
-        mAnnotations = new Vector<>();
+        mSeries = new Vector<XYSeries>();
+        mConfiguration = new Hashtable<String, Text>();
+        mAnnotations = new Vector<Annotation>();
     }
 
     public String getType() {
@@ -146,9 +146,9 @@ public class Graph implements Externalizable, DetailTemplate, Configurable {
     private void evaluateSeries(GraphData graphData, EvaluationContext context) {
         try {
             for (XYSeries s : mSeries) {
-                Hashtable<String, Text> expandableConfiguration = new Hashtable<>();
-                for (Enumeration<String> e = s.getExpandableConfigurationKeys(); e.hasMoreElements();) {
-                    String key = e.nextElement();
+                Hashtable<String, Text> expandableConfiguration = new Hashtable<String, Text>();
+                for (Enumeration e = s.getExpandableConfigurationKeys(); e.hasMoreElements();) {
+                    String key = (String) e.nextElement();
                     Text value = s.getConfiguration(key);
                     if (value != null) {
                         expandableConfiguration.put(key, value);
@@ -162,8 +162,8 @@ public class Graph implements Externalizable, DetailTemplate, Configurable {
                 Hashtable<String, Vector<String>> expandedConfiguration = new Hashtable();
                 for (TreeReference ref : refList) {
                     EvaluationContext refContext = new EvaluationContext(seriesContext, ref);
-                    for (Enumeration<String> e = expandableConfiguration.keys(); e.hasMoreElements();) {
-                        String key = e.nextElement();
+                    for (Enumeration e = expandableConfiguration.keys(); e.hasMoreElements();) {
+                        String key = (String) e.nextElement();
                         if (!expandedConfiguration.containsKey(key)) {
                             expandedConfiguration.put(key, new Vector<String>());
                         }
@@ -183,8 +183,8 @@ public class Graph implements Externalizable, DetailTemplate, Configurable {
                 }
                 graphData.addSeries(seriesData);
 
-                for (Enumeration<String> e = expandedConfiguration.keys(); e.hasMoreElements();) {
-                    String key = e.nextElement();
+                for (Enumeration e = expandedConfiguration.keys(); e.hasMoreElements();) {
+                    String key = (String) e.nextElement();
                     String json = "";
                     for (String pointValue : expandedConfiguration.get(key)) {
                         json += "," + "'" + pointValue.replaceAll("'", "&apos;") + "'";

--- a/backend/src/org/commcare/suite/model/graph/Graph.java
+++ b/backend/src/org/commcare/suite/model/graph/Graph.java
@@ -11,8 +11,6 @@ import org.javarosa.core.util.externalizable.ExtWrapListPoly;
 import org.javarosa.core.util.externalizable.ExtWrapMap;
 import org.javarosa.core.util.externalizable.Externalizable;
 import org.javarosa.core.util.externalizable.PrototypeFactory;
-import org.javarosa.xpath.XPathParseTool;
-import org.javarosa.xpath.expr.XPathExpression;
 import org.javarosa.xpath.parser.XPathSyntaxException;
 
 import java.io.DataInputStream;
@@ -37,7 +35,6 @@ public class Graph implements Externalizable, DetailTemplate, Configurable {
     private Vector<XYSeries> mSeries;
     private Hashtable<String, Text> mConfiguration;
     private Vector<Annotation> mAnnotations;
-    private Vector<String> mExpandableConfiguration;
 
     public Graph() {
         mSeries = new Vector<>();

--- a/backend/src/org/commcare/suite/model/graph/Graph.java
+++ b/backend/src/org/commcare/suite/model/graph/Graph.java
@@ -185,12 +185,18 @@ public class Graph implements Externalizable, DetailTemplate, Configurable {
 
                 for (Enumeration e = expandedConfiguration.keys(); e.hasMoreElements();) {
                     String key = (String) e.nextElement();
-                    String json = "";
+                    StringBuilder json = new StringBuilder();
                     for (String pointValue : expandedConfiguration.get(key)) {
-                        json += "," + "'" + pointValue.replaceAll("'", "&apos;") + "'";
+                        json.append(",'");
+                        json.append(pointValue.replaceAll("'", "&apos;"));
+                        json.append("'");
                     }
-                    json = "[" + json.substring(1) + "]";
-                    Text value = Text.PlainText(json);
+                    if (json.length() > 0) {
+                        json.deleteCharAt(0);
+                    }
+                    json.insert(0, "[");
+                    json.append("]");
+                    Text value = Text.PlainText(json.toString());
                     s.setConfiguration(key, value);
                 }
 

--- a/backend/src/org/commcare/suite/model/graph/Graph.java
+++ b/backend/src/org/commcare/suite/model/graph/Graph.java
@@ -146,12 +146,12 @@ public class Graph implements Externalizable, DetailTemplate, Configurable {
     private void evaluateSeries(GraphData graphData, EvaluationContext context) {
         try {
             for (XYSeries s : mSeries) {
-                Hashtable<String, Text> expandableConfiguration = new Hashtable<String, Text>();
-                for (Enumeration e = s.getExpandableConfigurationKeys(); e.hasMoreElements();) {
+                Hashtable<String, Text> pointConfiguration = new Hashtable<String, Text>();
+                for (Enumeration e = s.getPointConfigurationKeys(); e.hasMoreElements();) {
                     String key = (String) e.nextElement();
                     Text value = s.getConfiguration(key);
                     if (value != null) {
-                        expandableConfiguration.put(key, value);
+                        pointConfiguration.put(key, value);
                     }
                 }
 
@@ -162,12 +162,12 @@ public class Graph implements Externalizable, DetailTemplate, Configurable {
                 Hashtable<String, Vector<String>> expandedConfiguration = new Hashtable();
                 for (TreeReference ref : refList) {
                     EvaluationContext refContext = new EvaluationContext(seriesContext, ref);
-                    for (Enumeration e = expandableConfiguration.keys(); e.hasMoreElements();) {
+                    for (Enumeration e = pointConfiguration.keys(); e.hasMoreElements();) {
                         String key = (String) e.nextElement();
                         if (!expandedConfiguration.containsKey(key)) {
                             expandedConfiguration.put(key, new Vector<String>());
                         }
-                        String value = expandableConfiguration.get(key).evaluate(refContext);
+                        String value = pointConfiguration.get(key).evaluate(refContext);
                         expandedConfiguration.get(key).addElement(value);
                     }
                     String x = s.evaluateX(refContext);

--- a/backend/src/org/commcare/suite/model/graph/XYSeries.java
+++ b/backend/src/org/commcare/suite/model/graph/XYSeries.java
@@ -46,8 +46,8 @@ public class XYSeries implements Externalizable, Configurable {
 
     public XYSeries(String nodeSet) {
         mNodeSet = XPathReference.getPathExpr(nodeSet).getReference(true);
-        mConfiguration = new Hashtable<>();
-        mExpandableConfiguration = new Vector<>();
+        mConfiguration = new Hashtable<String, Text>();
+        mExpandableConfiguration = new Vector<String>();
         mExpandableConfiguration.addElement("bar-color");
     }
 

--- a/backend/src/org/commcare/suite/model/graph/XYSeries.java
+++ b/backend/src/org/commcare/suite/model/graph/XYSeries.java
@@ -5,6 +5,7 @@ import org.javarosa.core.model.condition.EvaluationContext;
 import org.javarosa.core.model.instance.TreeReference;
 import org.javarosa.core.util.externalizable.DeserializationException;
 import org.javarosa.core.util.externalizable.ExtUtil;
+import org.javarosa.core.util.externalizable.ExtWrapList;
 import org.javarosa.core.util.externalizable.ExtWrapMap;
 import org.javarosa.core.util.externalizable.Externalizable;
 import org.javarosa.core.util.externalizable.PrototypeFactory;
@@ -18,6 +19,7 @@ import java.io.DataOutputStream;
 import java.io.IOException;
 import java.util.Enumeration;
 import java.util.Hashtable;
+import java.util.Vector;
 
 /**
  * Single series (line) on an xy graph.
@@ -27,6 +29,7 @@ import java.util.Hashtable;
 public class XYSeries implements Externalizable, Configurable {
     private TreeReference mNodeSet;
     private Hashtable<String, Text> mConfiguration;
+    private Vector<String> mExpandableConfiguration;
 
     private String mX;
     private String mY;
@@ -43,7 +46,9 @@ public class XYSeries implements Externalizable, Configurable {
 
     public XYSeries(String nodeSet) {
         mNodeSet = XPathReference.getPathExpr(nodeSet).getReference(true);
-        mConfiguration = new Hashtable<String, Text>();
+        mConfiguration = new Hashtable<>();
+        mExpandableConfiguration = new Vector<>();
+        mExpandableConfiguration.addElement("bar-color");
     }
 
     public TreeReference getNodeSet() {
@@ -72,6 +77,10 @@ public class XYSeries implements Externalizable, Configurable {
         mConfiguration.put(key, value);
     }
 
+    public Enumeration<String> getExpandableConfigurationKeys() {
+        return mExpandableConfiguration.elements();
+    }
+
     public Text getConfiguration(String key) {
         return mConfiguration.get(key);
     }
@@ -90,6 +99,7 @@ public class XYSeries implements Externalizable, Configurable {
         mY = ExtUtil.readString(in);
         mNodeSet = (TreeReference)ExtUtil.read(in, TreeReference.class, pf);
         mConfiguration = (Hashtable<String, Text>)ExtUtil.read(in, new ExtWrapMap(String.class, Text.class), pf);
+        mExpandableConfiguration =  (Vector<String>)ExtUtil.read(in, new ExtWrapList(String.class), pf);
     }
 
     /*
@@ -101,6 +111,7 @@ public class XYSeries implements Externalizable, Configurable {
         ExtUtil.writeString(out, mY);
         ExtUtil.write(out, mNodeSet);
         ExtUtil.write(out, new ExtWrapMap(mConfiguration));
+        ExtUtil.write(out, new ExtWrapList(mExpandableConfiguration));
     }
 
     /*

--- a/backend/src/org/commcare/suite/model/graph/XYSeries.java
+++ b/backend/src/org/commcare/suite/model/graph/XYSeries.java
@@ -29,6 +29,10 @@ import java.util.Vector;
 public class XYSeries implements Externalizable, Configurable {
     private TreeReference mNodeSet;
     private Hashtable<String, Text> mConfiguration;
+
+    // List of keys that configure individual points. For these keys, the Text stored in
+    // mConfiguration is an XPath expression, which during evaluation will be applied to
+    // each point in turn to produce a list of one value for each point.
     private Vector<String> mPointConfiguration;
 
     private String mX;

--- a/backend/src/org/commcare/suite/model/graph/XYSeries.java
+++ b/backend/src/org/commcare/suite/model/graph/XYSeries.java
@@ -29,7 +29,7 @@ import java.util.Vector;
 public class XYSeries implements Externalizable, Configurable {
     private TreeReference mNodeSet;
     private Hashtable<String, Text> mConfiguration;
-    private Vector<String> mExpandableConfiguration;
+    private Vector<String> mPointConfiguration;
 
     private String mX;
     private String mY;
@@ -47,8 +47,8 @@ public class XYSeries implements Externalizable, Configurable {
     public XYSeries(String nodeSet) {
         mNodeSet = XPathReference.getPathExpr(nodeSet).getReference(true);
         mConfiguration = new Hashtable<String, Text>();
-        mExpandableConfiguration = new Vector<String>();
-        mExpandableConfiguration.addElement("bar-color");
+        mPointConfiguration = new Vector<String>();
+        mPointConfiguration.addElement("bar-color");
     }
 
     public TreeReference getNodeSet() {
@@ -77,8 +77,8 @@ public class XYSeries implements Externalizable, Configurable {
         mConfiguration.put(key, value);
     }
 
-    public Enumeration<String> getExpandableConfigurationKeys() {
-        return mExpandableConfiguration.elements();
+    public Enumeration<String> getPointConfigurationKeys() {
+        return mPointConfiguration.elements();
     }
 
     public Text getConfiguration(String key) {
@@ -99,7 +99,7 @@ public class XYSeries implements Externalizable, Configurable {
         mY = ExtUtil.readString(in);
         mNodeSet = (TreeReference)ExtUtil.read(in, TreeReference.class, pf);
         mConfiguration = (Hashtable<String, Text>)ExtUtil.read(in, new ExtWrapMap(String.class, Text.class), pf);
-        mExpandableConfiguration =  (Vector<String>)ExtUtil.read(in, new ExtWrapList(String.class), pf);
+        mPointConfiguration =  (Vector<String>)ExtUtil.read(in, new ExtWrapList(String.class), pf);
     }
 
     /*
@@ -111,7 +111,7 @@ public class XYSeries implements Externalizable, Configurable {
         ExtUtil.writeString(out, mY);
         ExtUtil.write(out, mNodeSet);
         ExtUtil.write(out, new ExtWrapMap(mConfiguration));
-        ExtUtil.write(out, new ExtWrapList(mExpandableConfiguration));
+        ExtUtil.write(out, new ExtWrapList(mPointConfiguration));
     }
 
     /*


### PR DESCRIPTION
TDH wants to support bar-specific colors so you can highlight the current user's data in mobile UCR. Since graphing doesn't have the concept of point-specific configuration, this is implemented by introducing a new series-level parameter, `bar-color` which accepts a function. During evaluation, the function is applied to each node in the series, building up an array, and the array is then encoded in JSON and used to overwrite the original function.

http://manage.dimagi.com/default.asp?187761