### PR TITLE
Only expand point-level configuration once

### DIFF
--- a/backend/src/org/commcare/suite/model/graph/Graph.java
+++ b/backend/src/org/commcare/suite/model/graph/Graph.java
@@ -197,7 +197,7 @@ public class Graph implements Externalizable, DetailTemplate, Configurable {
                     json.insert(0, "[");
                     json.append("]");
                     Text value = Text.PlainText(json.toString());
-                    s.setConfiguration(key, value);
+                    s.setExpandedConfiguration(key, value);
                 }
 
                 // Handle configuration after data, since data processing may update configuration
@@ -214,5 +214,4 @@ public class Graph implements Externalizable, DetailTemplate, Configurable {
             e.printStackTrace();
         }
     }
-
 }

--- a/backend/src/org/commcare/suite/model/graph/XYSeries.java
+++ b/backend/src/org/commcare/suite/model/graph/XYSeries.java
@@ -32,7 +32,8 @@ public class XYSeries implements Externalizable, Configurable {
 
     // List of keys that configure individual points. For these keys, the Text stored in
     // mConfiguration is an XPath expression, which during evaluation will be applied to
-    // each point in turn to produce a list of one value for each point.
+    // each point in turn to produce a list of one value for each point. As the "expanded",
+    // point-level values are set, keys will be removed from this list.
     private Vector<String> mPointConfiguration;
 
     private String mX;
@@ -79,6 +80,11 @@ public class XYSeries implements Externalizable, Configurable {
 
     public void setConfiguration(String key, Text value) {
         mConfiguration.put(key, value);
+    }
+
+    public void setExpandedConfiguration(String key, Text value) {
+        mPointConfiguration.remove(key);
+        setConfiguration(key, value);
     }
 
     public Enumeration getPointConfigurationKeys() {


### PR DESCRIPTION
`bar-color` configuration was getting re-expanded each time the graph was viewed:

first evaluation, bar-color goes from `if(number > 2, '#ffffff00', '#660000ff')` to `['#33ff00ff','#33ff00ff','#33ff00ff']`

second evaluation, bar-color goes from `['#33ff00ff','#33ff00ff','#33ff00ff']` to `['['#33ff00ff','#33ff00ff','#33ff00ff']', '['#33ff00ff','#33ff00ff','#33ff00ff']', '['#33ff00ff','#33ff00ff','#33ff00ff']']`

...and then CommCare crashes. Update to only evaluate point-level configuration once.