### PR TITLE
Fix for last J2ME Crashes related to session state and fixtures

### DIFF
--- a/application/src/org/commcare/util/CommCareContext.java
+++ b/application/src/org/commcare/util/CommCareContext.java
@@ -459,7 +459,7 @@ public class CommCareContext {
 
     protected void registerAddtlStorage () {
         //do nothing
-        StorageManager.registerStorage("fixture", FormInstance.class);
+        StorageManager.registerStorage(FormInstance.STORAGE_KEY, FormInstance.class);
     }
 
     protected void initReferences() {
@@ -649,27 +649,6 @@ public class CommCareContext {
 
         //1) tx queue is self-managing
         //do nothing
-
-        //2) saved forms (keep forms not yet recorded; sent/unsent status should matter in future, but not now, because new tx layer is naive)
-        purgeRMS(FormInstance.STORAGE_KEY,
-            new EntityFilter<FormInstance> () {
-                EntityFilter<FormInstance> antiFilter = new RecentFormFilter();
-
-                //do the opposite of the recent form filter; i.e., if form shows up in the 'unrecorded forms' list, it is NOT safe to delete
-                public int preFilter (int id, Hashtable metaData) {
-                    int prefilter = antiFilter.preFilter(id, metaData);
-                    if(prefilter == EntityFilter.PREFILTER_FILTER) {
-                        return EntityFilter.PREFILTER_FILTER;
-                    }
-                    return  prefilter == EntityFilter.PREFILTER_INCLUDE ?
-                            EntityFilter.PREFILTER_EXCLUDE : EntityFilter.PREFILTER_INCLUDE;
-                }
-
-                public boolean matches(FormInstance sf) {
-                    return !antiFilter.matches(sf);
-                }
-            }, deletedLog);
-
 
         //3) cases (delete cases that are closed AND have no open cases which index them)
         purgeRMS(Case.STORAGE_KEY, caseFilter(), deletedLog);

--- a/application/src/org/commcare/util/CommCareSessionController.java
+++ b/application/src/org/commcare/util/CommCareSessionController.java
@@ -222,6 +222,9 @@ public class CommCareSessionController {
                 protected void goHome() {
                     //Ok, now we just need to figure out if it's time to go home, or time to fire up a new session from the stack
                     if (session.finishExecuteAndPop(session.getEvaluationContext(getIif()))) {
+                        //Clear out any local caching, since transactions may have occurred since it was cached.
+                        initializer = null;
+
                         next();
                     } else {
                         J2MEDisplay.startStateWithLoadingScreen(new CommCareHomeState());

--- a/application/src/org/commcare/util/CommCareSessionController.java
+++ b/application/src/org/commcare/util/CommCareSessionController.java
@@ -220,11 +220,11 @@ public class CommCareSessionController {
 
             CommCareFormEntryState state = new CommCareFormEntryState(title,xmlns, getPreloaders(), CommCareContext._().getFuncHandlers(), getIif()) {
                 protected void goHome() {
+                    //Clear out any local caching, since transactions may have occurred since it was cached.
+                    initializer = null;
+
                     //Ok, now we just need to figure out if it's time to go home, or time to fire up a new session from the stack
                     if (session.finishExecuteAndPop(session.getEvaluationContext(getIif()))) {
-                        //Clear out any local caching, since transactions may have occurred since it was cached.
-                        initializer = null;
-
                         next();
                     } else {
                         J2MEDisplay.startStateWithLoadingScreen(new CommCareHomeState());


### PR DESCRIPTION
Fixes two major bugs:
1) Because we moved where we were storing fixtures, we tripped across some old old code that was trying to clean Form instances 

2) Session/Runtime instances were incorrectly being retained after form processing, rather than being rebuilt.

Ticket:
http://manage.dimagi.com/default.asp?183837