### PR TITLE
Build: Remove api dir from test sourceset

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,15 +40,6 @@ sourceSets {
             srcDir 'cases/resources'
         }
   }
-  test {
-      java {
-          srcDir 'tests/test'
-          srcDir 'api'
-      }
-      resources{
-          srcDir 'tests/resources'
-      }
-  }
 
   cli {
       java {
@@ -62,6 +53,16 @@ sourceSets {
             compileClasspath += main.output
         }
     }
+
+    test {
+        java {
+            srcDir 'tests/test'
+            compileClasspath += api.output
+        }
+        resources{
+            srcDir 'tests/resources'
+        }
+    }
 }
 
 dependencies {
@@ -71,6 +72,7 @@ dependencies {
       cliCompile 'commons-cli:commons-cli:1.3.1'
 
       testCompile sourceSets.main.output
+      testCompile sourceSets.api.output
       testCompile sourceSets.cli.output
       testCompile group: 'junit', name: 'junit', version: '4.+'
       testCompile 'org.json:json:20140107'


### PR DESCRIPTION
Adding `srcDir 'api'` to the `test` source set made it look like that dir was full of tests in Android Studio, which is confusing because it isn't. 

Wire things up such that tests have access to api code without making it look like api code contain tests.