### PR TITLE
Return "" instead of null on unfound session step extra

### DIFF
--- a/backend/src/org/commcare/session/SessionFrame.java
+++ b/backend/src/org/commcare/session/SessionFrame.java
@@ -165,7 +165,7 @@ public class SessionFrame implements Externalizable {
             StackFrameStep topStep = steps.elementAt(steps.size() - 1);
             return topStep.getExtra(key);
         }
-        return null;
+        return "";
     }
 
     @Override

--- a/backend/src/org/commcare/suite/model/StackFrameStep.java
+++ b/backend/src/org/commcare/suite/model/StackFrameStep.java
@@ -76,7 +76,12 @@ public class StackFrameStep implements Externalizable {
     }
 
     public String getExtra(String key) {
-        return extras.get(key);
+        String value = extras.get(key);
+        if (value == null) {
+            return "";
+        } else {
+            return value;
+        }
     }
 
     /**

--- a/backend/src/org/commcare/suite/model/StackFrameStep.java
+++ b/backend/src/org/commcare/suite/model/StackFrameStep.java
@@ -72,7 +72,9 @@ public class StackFrameStep implements Externalizable {
     }
 
     public void addExtra(String key, String value) {
-        extras.put(key, value);
+        if (value != null) {
+            extras.put(key, value);
+        }
     }
 
     public String getExtra(String key) {

--- a/tests/test/org/commcare/backend/session/test/SessionNavigatorTests.java
+++ b/tests/test/org/commcare/backend/session/test/SessionNavigatorTests.java
@@ -177,6 +177,6 @@ public class SessionNavigatorTests {
         triggerSessionStepAndCheckResultCode(SessionNavigator.GET_COMMAND);
         session.setCommand("m0");
         triggerSessionStepAndCheckResultCode(SessionNavigator.GET_COMMAND);
-        Assert.assertEquals(null, session.getCurrentFrameStepExtra(LAST_QUERY_KEY));
+        Assert.assertEquals("", session.getCurrentFrameStepExtra(LAST_QUERY_KEY));
     }
 }


### PR DESCRIPTION
NPE was coming up because `Hastable.put` throws an NPE when you try to store a `null` value. The way this currently was manifesting in the code, the workaround is to return `""` instead of `null` if a key isn't found in the `extras` hashtable. For good measure I also added in a `null`-check when storing values in `extras` to prevent the NPE in all cases.

Fix for https://commcare-acralyzer.cloudant.com/acralyzer/_design/acralyzer/index.html#/reports-browser/commcare-odk/bug/24a1fdfee10ba8de2fa85a5b49eedd72