### PR TITLE
Lift entry lookup logic out of unnecessary inner loop 

### DIFF
--- a/backend/src/org/commcare/session/CommCareSession.java
+++ b/backend/src/org/commcare/session/CommCareSession.java
@@ -104,29 +104,30 @@ public class CommCareSession {
         return new Vector<Entry>();
     }
 
-    private Vector<Entry> getEntriesFromMenu(Menu menu, OrderedHashtable<String, String> data) {
+    private Vector<Entry> getEntriesFromMenu(Menu menu,
+                                             OrderedHashtable<String, String> data) {
         Vector<Entry> entries = new Vector<Entry>();
         Hashtable<String, Entry> map = platform.getMenuMap();
-            //We're in a menu we have a set of requirements which
-            //need to be fulfilled
-            for (String cmd : menu.getCommandIds()) {
-                Entry e = map.get(cmd);
-                if (e == null) {
-                    throw new RuntimeException("No entry found for menu command [" + cmd + "]");
-                }
-                boolean valid = true;
-                Vector<SessionDatum> requirements = e.getSessionDataReqs();
-                if (requirements.size() >= data.size()) {
-                    for (int i = 0; i < data.size(); ++i) {
-                        if (!requirements.elementAt(i).getDataId().equals(data.keyAt(i))) {
-                            valid = false;
-                        }
+        //We're in a menu we have a set of requirements which
+        //need to be fulfilled
+        for (String cmd : menu.getCommandIds()) {
+            Entry e = map.get(cmd);
+            if (e == null) {
+                throw new RuntimeException("No entry found for menu command [" + cmd + "]");
+            }
+            boolean valid = true;
+            Vector<SessionDatum> requirements = e.getSessionDataReqs();
+            if (requirements.size() >= data.size()) {
+                for (int i = 0; i < data.size(); ++i) {
+                    if (!requirements.elementAt(i).getDataId().equals(data.keyAt(i))) {
+                        valid = false;
                     }
                 }
-                if (valid) {
-                    entries.addElement(e);
-                }
             }
+            if (valid) {
+                entries.addElement(e);
+            }
+        }
         return entries;
     }
 

--- a/backend/src/org/commcare/session/CommCareSession.java
+++ b/backend/src/org/commcare/session/CommCareSession.java
@@ -92,12 +92,12 @@ public class CommCareSession {
                 if (commandId.equals(m.getId())) {
                     return getEntriesFromMenu(m, data);
                 }
+            }
 
-                if (s.getEntries().containsKey(commandId)) {
-                    Vector<Entry> entries = new Vector<Entry>();
-                    entries.addElement(s.getEntries().get(commandId));
-                    return entries;
-                }
+            if (s.getEntries().containsKey(commandId)) {
+                Vector<Entry> entries = new Vector<Entry>();
+                entries.addElement(s.getEntries().get(commandId));
+                return entries;
             }
         }
 

--- a/backend/src/org/commcare/session/CommCareSession.java
+++ b/backend/src/org/commcare/session/CommCareSession.java
@@ -86,31 +86,27 @@ public class CommCareSession {
      */
     private Vector<Entry> getEntriesForCommand(String commandId,
                                                OrderedHashtable<String, String> data) {
-        Hashtable<String, Entry> map = platform.getMenuMap();
-        Menu menu = null;
-        Entry entry = null;
-        top:
         for (Suite s : platform.getInstalledSuites()) {
             for (Menu m : s.getMenus()) {
                 // We need to see if everything in this menu can be matched
                 if (commandId.equals(m.getId())) {
-                    menu = m;
-                    break top;
+                    return getEntriesFromMenu(m, data);
                 }
 
                 if (s.getEntries().containsKey(commandId)) {
-                    entry = s.getEntries().get(commandId);
-                    break top;
+                    Vector<Entry> entries = new Vector<Entry>();
+                    entries.addElement(s.getEntries().get(commandId));
+                    return entries;
                 }
             }
         }
 
-        Vector<Entry> entries = new Vector<Entry>();
-        if (entry != null) {
-            entries.addElement(entry);
-        }
+        return new Vector<Entry>();
+    }
 
-        if (menu != null) {
+    private Vector<Entry> getEntriesFromMenu(Menu menu, OrderedHashtable<String, String> data) {
+        Vector<Entry> entries = new Vector<Entry>();
+        Hashtable<String, Entry> map = platform.getMenuMap();
             //We're in a menu we have a set of requirements which
             //need to be fulfilled
             for (String cmd : menu.getCommandIds()) {
@@ -131,7 +127,6 @@ public class CommCareSession {
                     entries.addElement(e);
                 }
             }
-        }
         return entries;
     }
 


### PR DESCRIPTION
`CommCareSession.getEntriesForCommand` has a doubly nested for loop and some of the lookup logic didn't need to be in the inner loop.