### PR TITLE
Sync request parser

### DIFF
--- a/backend/src/org/commcare/suite/model/Entry.java
+++ b/backend/src/org/commcare/suite/model/Entry.java
@@ -52,7 +52,9 @@ public abstract class Entry implements Externalizable, MenuDisplayable {
         this.assertions = assertions;
     }
 
-    public abstract boolean isView();
+    public boolean isView() {
+        return false;
+    }
 
     /**
      * @return the ID of this entry command. Used by Menus to determine

--- a/backend/src/org/commcare/suite/model/FormEntry.java
+++ b/backend/src/org/commcare/suite/model/FormEntry.java
@@ -38,11 +38,6 @@ public class FormEntry extends Entry {
         this.xFormNamespace = formNamespace;
     }
 
-    @Override
-    public boolean isView() {
-        return false;
-    }
-
     /**
      * @return The XForm Namespce of the form which should be filled out in
      * the form entry session triggered by this action.

--- a/backend/src/org/commcare/suite/model/RemoteQuery.java
+++ b/backend/src/org/commcare/suite/model/RemoteQuery.java
@@ -2,6 +2,8 @@ package org.commcare.suite.model;
 
 import org.javarosa.core.model.instance.TreeReference;
 import org.javarosa.core.util.externalizable.DeserializationException;
+import org.javarosa.core.util.externalizable.ExtUtil;
+import org.javarosa.core.util.externalizable.ExtWrapMap;
 import org.javarosa.core.util.externalizable.Externalizable;
 import org.javarosa.core.util.externalizable.PrototypeFactory;
 
@@ -35,9 +37,17 @@ public class RemoteQuery implements Externalizable {
     @Override
     public void readExternal(DataInputStream in, PrototypeFactory pf)
             throws IOException, DeserializationException {
+        url = ExtUtil.readString(in);
+        storageInstance = ExtUtil.readString(in);
+        hiddenQueryValues = (Hashtable<String, TreeReference>)ExtUtil.read(in, new ExtWrapMap(String.class, TreeReference.class));
+        userQueryPrompts = (Hashtable<String, DisplayUnit>)ExtUtil.read(in, new ExtWrapMap(String.class, DisplayUnit.class));
     }
 
     @Override
     public void writeExternal(DataOutputStream out) throws IOException {
+        ExtUtil.writeString(out, url);
+        ExtUtil.writeString(out, storageInstance);
+        ExtUtil.write(out, new ExtWrapMap(hiddenQueryValues));
+        ExtUtil.write(out, new ExtWrapMap(userQueryPrompts));
     }
 }

--- a/backend/src/org/commcare/suite/model/RemoteQuery.java
+++ b/backend/src/org/commcare/suite/model/RemoteQuery.java
@@ -13,11 +13,14 @@ import java.io.IOException;
 import java.util.Hashtable;
 
 /**
+ * Entry config for querying a remote server with user and session provided
+ * parameters and storing the xml data response in an instance.
+ *
  * @author Phillip Mates (pmates@dimagi.com).
  */
 public class RemoteQuery implements Externalizable {
-    Hashtable<String, TreeReference> hiddenQueryValues;
-    Hashtable<String, DisplayUnit> userQueryPrompts;
+    private Hashtable<String, TreeReference> hiddenQueryValues;
+    private Hashtable<String, DisplayUnit> userQueryPrompts;
     private String storageInstance;
     private String url;
 
@@ -39,8 +42,12 @@ public class RemoteQuery implements Externalizable {
             throws IOException, DeserializationException {
         url = ExtUtil.readString(in);
         storageInstance = ExtUtil.readString(in);
-        hiddenQueryValues = (Hashtable<String, TreeReference>)ExtUtil.read(in, new ExtWrapMap(String.class, TreeReference.class));
-        userQueryPrompts = (Hashtable<String, DisplayUnit>)ExtUtil.read(in, new ExtWrapMap(String.class, DisplayUnit.class));
+        hiddenQueryValues =
+                (Hashtable<String, TreeReference>)ExtUtil.read(in,
+                        new ExtWrapMap(String.class, TreeReference.class));
+        userQueryPrompts =
+                (Hashtable<String, DisplayUnit>)ExtUtil.read(in,
+                        new ExtWrapMap(String.class, DisplayUnit.class));
     }
 
     @Override

--- a/backend/src/org/commcare/suite/model/RemoteQuery.java
+++ b/backend/src/org/commcare/suite/model/RemoteQuery.java
@@ -19,7 +19,17 @@ public class RemoteQuery implements Externalizable {
     private String storageInstance;
     private String url;
 
+    @SuppressWarnings("unused")
     public RemoteQuery() {
+    }
+
+    public RemoteQuery(String url, String storageInstance,
+                       Hashtable<String, TreeReference> hiddenQueryValues,
+                       Hashtable<String, DisplayUnit> userQueryPrompts) {
+        this.url = url;
+        this.storageInstance = storageInstance;
+        this.hiddenQueryValues = hiddenQueryValues;
+        this.userQueryPrompts = userQueryPrompts;
     }
 
     @Override

--- a/backend/src/org/commcare/suite/model/RemoteQuery.java
+++ b/backend/src/org/commcare/suite/model/RemoteQuery.java
@@ -1,0 +1,33 @@
+package org.commcare.suite.model;
+
+import org.javarosa.core.model.instance.TreeReference;
+import org.javarosa.core.util.externalizable.DeserializationException;
+import org.javarosa.core.util.externalizable.Externalizable;
+import org.javarosa.core.util.externalizable.PrototypeFactory;
+
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.util.Hashtable;
+
+/**
+ * @author Phillip Mates (pmates@dimagi.com).
+ */
+public class RemoteQuery implements Externalizable {
+    Hashtable<String, TreeReference> hiddenQueryValues;
+    Hashtable<String, DisplayUnit> userQueryPrompts;
+    private String storageInstance;
+    private String url;
+
+    public RemoteQuery() {
+    }
+
+    @Override
+    public void readExternal(DataInputStream in, PrototypeFactory pf)
+            throws IOException, DeserializationException {
+    }
+
+    @Override
+    public void writeExternal(DataOutputStream out) throws IOException {
+    }
+}

--- a/backend/src/org/commcare/suite/model/SyncEntry.java
+++ b/backend/src/org/commcare/suite/model/SyncEntry.java
@@ -1,12 +1,9 @@
 package org.commcare.suite.model;
 
 import org.javarosa.core.model.instance.DataInstance;
-import org.javarosa.core.model.instance.TreeReference;
 import org.javarosa.core.util.externalizable.DeserializationException;
 import org.javarosa.core.util.externalizable.ExtUtil;
 import org.javarosa.core.util.externalizable.ExtWrapListPoly;
-import org.javarosa.core.util.externalizable.ExtWrapMap;
-import org.javarosa.core.util.externalizable.Externalizable;
 import org.javarosa.core.util.externalizable.PrototypeFactory;
 
 import java.io.DataInputStream;
@@ -16,6 +13,10 @@ import java.util.Hashtable;
 import java.util.Vector;
 
 /**
+ * Suite entry for performing a synchronous query/post request to an external
+ * server. Lifecycle is: gather query params, query the server, process
+ * response data, and complete the transaction with a post to the server.
+ *
  * @author Phillip Mates (pmates@dimagi.com).
  */
 public class SyncEntry extends Entry {
@@ -28,18 +29,15 @@ public class SyncEntry extends Entry {
     }
 
     public SyncEntry(String commandId, DisplayUnit display,
-                     Vector<SessionDatum> data, Hashtable<String, DataInstance> instances,
-                     Vector<StackOperation> stackOperations, AssertionSet assertions,
+                     Vector<SessionDatum> data,
+                     Hashtable<String, DataInstance> instances,
+                     Vector<StackOperation> stackOperations,
+                     AssertionSet assertions,
                      SyncPost post, Vector<RemoteQuery> queries) {
         super(commandId, display, data, instances, stackOperations, assertions);
 
         this.queries = queries;
         this.post = post;
-    }
-
-    @Override
-    public boolean isView() {
-        return false;
     }
 
     @Override

--- a/backend/src/org/commcare/suite/model/SyncEntry.java
+++ b/backend/src/org/commcare/suite/model/SyncEntry.java
@@ -1,0 +1,68 @@
+package org.commcare.suite.model;
+
+import org.javarosa.core.model.instance.DataInstance;
+import org.javarosa.core.model.instance.TreeReference;
+import org.javarosa.core.util.externalizable.DeserializationException;
+import org.javarosa.core.util.externalizable.Externalizable;
+import org.javarosa.core.util.externalizable.PrototypeFactory;
+
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.util.Hashtable;
+import java.util.Vector;
+
+/**
+ * @author Phillip Mates (pmates@dimagi.com).
+ */
+public class SyncEntry extends Entry {
+    private Vector<RemoteQuery> queries;
+    private SyncPost post;
+
+    /**
+     * Serialization only!
+     */
+    public SyncEntry() {
+
+    }
+
+    public SyncEntry(String commandId, DisplayUnit display,
+                     Vector<SessionDatum> data, Hashtable<String, DataInstance> instances,
+                     Vector<StackOperation> stackOperations, AssertionSet assertions,
+                     SyncPost post, Vector<RemoteQuery> queries) {
+        super(commandId, display, data, instances, stackOperations, assertions);
+
+        this.queries = queries;
+        this.post = post;
+    }
+
+    @Override
+    public boolean isView() {
+        return false;
+    }
+
+    @Override
+    public void readExternal(DataInputStream in, PrototypeFactory pf)
+            throws IOException, DeserializationException {
+        super.readExternal(in, pf);
+    }
+
+    @Override
+    public void writeExternal(DataOutputStream out) throws IOException {
+        super.writeExternal(out);
+    }
+
+    public static class SyncPost implements Externalizable {
+        private String postUrl;
+        private Hashtable<String, TreeReference> postKeys;
+
+        @Override
+        public void readExternal(DataInputStream in, PrototypeFactory pf)
+                throws IOException, DeserializationException {
+        }
+
+        @Override
+        public void writeExternal(DataOutputStream out) throws IOException {
+        }
+    }
+}

--- a/backend/src/org/commcare/suite/model/SyncEntry.java
+++ b/backend/src/org/commcare/suite/model/SyncEntry.java
@@ -3,6 +3,9 @@ package org.commcare.suite.model;
 import org.javarosa.core.model.instance.DataInstance;
 import org.javarosa.core.model.instance.TreeReference;
 import org.javarosa.core.util.externalizable.DeserializationException;
+import org.javarosa.core.util.externalizable.ExtUtil;
+import org.javarosa.core.util.externalizable.ExtWrapListPoly;
+import org.javarosa.core.util.externalizable.ExtWrapMap;
 import org.javarosa.core.util.externalizable.Externalizable;
 import org.javarosa.core.util.externalizable.PrototypeFactory;
 
@@ -43,24 +46,16 @@ public class SyncEntry extends Entry {
     public void readExternal(DataInputStream in, PrototypeFactory pf)
             throws IOException, DeserializationException {
         super.readExternal(in, pf);
+
+        post = (SyncPost)ExtUtil.read(in, SyncPost.class, pf);
+        queries = (Vector<RemoteQuery>)ExtUtil.read(in, new ExtWrapListPoly(), pf);
     }
 
     @Override
     public void writeExternal(DataOutputStream out) throws IOException {
         super.writeExternal(out);
-    }
 
-    public static class SyncPost implements Externalizable {
-        private String postUrl;
-        private Hashtable<String, TreeReference> postKeys;
-
-        @Override
-        public void readExternal(DataInputStream in, PrototypeFactory pf)
-                throws IOException, DeserializationException {
-        }
-
-        @Override
-        public void writeExternal(DataOutputStream out) throws IOException {
-        }
+        ExtUtil.write(out, post);
+        ExtUtil.write(out, new ExtWrapListPoly(queries));
     }
 }

--- a/backend/src/org/commcare/suite/model/SyncEntry.java
+++ b/backend/src/org/commcare/suite/model/SyncEntry.java
@@ -19,9 +19,7 @@ public class SyncEntry extends Entry {
     private Vector<RemoteQuery> queries;
     private SyncPost post;
 
-    /**
-     * Serialization only!
-     */
+    @SuppressWarnings("unused")
     public SyncEntry() {
 
     }

--- a/backend/src/org/commcare/suite/model/SyncPost.java
+++ b/backend/src/org/commcare/suite/model/SyncPost.java
@@ -22,6 +22,10 @@ public class SyncPost implements Externalizable {
     private String postUrl;
     private Hashtable<String, TreeReference> postKeys;
 
+    @SuppressWarnings("unused")
+    public SyncPost() {
+    }
+
     public SyncPost(String postUrl, Hashtable<String, TreeReference> postKeys) {
         this.postUrl = (postUrl == null) ? "" : postUrl;
         this.postKeys = postKeys;

--- a/backend/src/org/commcare/suite/model/SyncPost.java
+++ b/backend/src/org/commcare/suite/model/SyncPost.java
@@ -13,6 +13,9 @@ import java.io.IOException;
 import java.util.Hashtable;
 
 /**
+ * Entry config for posting data to a remote server as part of synchronous
+ * request transaction.
+ *
  * @author Phillip Mates (pmates@dimagi.com).
  */
 public class SyncPost implements Externalizable {
@@ -28,7 +31,8 @@ public class SyncPost implements Externalizable {
     public void readExternal(DataInputStream in, PrototypeFactory pf)
             throws IOException, DeserializationException {
         postUrl = ExtUtil.readString(in);
-        postKeys = (Hashtable<String, TreeReference>)ExtUtil.read(in, new ExtWrapMap(String.class, TreeReference.class));
+        postKeys = (Hashtable<String, TreeReference>)ExtUtil.read(in,
+                new ExtWrapMap(String.class, TreeReference.class));
     }
 
     @Override

--- a/backend/src/org/commcare/suite/model/SyncPost.java
+++ b/backend/src/org/commcare/suite/model/SyncPost.java
@@ -1,0 +1,39 @@
+package org.commcare.suite.model;
+
+import org.javarosa.core.model.instance.TreeReference;
+import org.javarosa.core.util.externalizable.DeserializationException;
+import org.javarosa.core.util.externalizable.ExtUtil;
+import org.javarosa.core.util.externalizable.ExtWrapMap;
+import org.javarosa.core.util.externalizable.Externalizable;
+import org.javarosa.core.util.externalizable.PrototypeFactory;
+
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.util.Hashtable;
+
+/**
+ * @author Phillip Mates (pmates@dimagi.com).
+ */
+public class SyncPost implements Externalizable {
+    private String postUrl;
+    private Hashtable<String, TreeReference> postKeys;
+
+    public SyncPost(String postUrl, Hashtable<String, TreeReference> postKeys) {
+        this.postUrl = (postUrl == null) ? "" : postUrl;
+        this.postKeys = postKeys;
+    }
+
+    @Override
+    public void readExternal(DataInputStream in, PrototypeFactory pf)
+            throws IOException, DeserializationException {
+        postUrl = ExtUtil.readString(in);
+        postKeys = (Hashtable<String, TreeReference>)ExtUtil.read(in, new ExtWrapMap(String.class, TreeReference.class));
+    }
+
+    @Override
+    public void writeExternal(DataOutputStream out) throws IOException {
+        ExtUtil.writeString(out, postUrl);
+        ExtUtil.write(out, new ExtWrapMap(postKeys));
+    }
+}

--- a/backend/src/org/commcare/xml/EntryParser.java
+++ b/backend/src/org/commcare/xml/EntryParser.java
@@ -21,7 +21,7 @@ import java.util.Vector;
  * @author ctsims
  */
 public class EntryParser extends CommCareElementParser<Entry> {
-    private boolean isEntry = true;
+    private final boolean isEntry;
 
     private EntryParser(KXmlParser parser, boolean isEntry) {
         super(parser);
@@ -52,24 +52,25 @@ public class EntryParser extends CommCareElementParser<Entry> {
         AssertionSet assertions = null;
 
         while (nextTagInBlock(block)) {
-            if (parser.getName().equals("form")) {
+            String tagName = parser.getName();
+            if ("form".equals(tagName)) {
                 if (!isEntry) {
-                    throw new InvalidStructureException("<view>'s cannot specify XForms!!", this.parser);
+                    throw new InvalidStructureException("<" + block + ">'s cannot specify XForms!!", parser);
                 }
                 xFormNamespace = parser.nextText();
-            } else if (parser.getName().equals("command")) {
+            } else if ("command".equals(tagName)) {
                 commandId = parser.getAttributeValue(null, "id");
                 display = parseCommandDisplay();
-            } else if ("instance".equals(parser.getName().toLowerCase())) {
+            } else if ("instance".equals(tagName.toLowerCase())) {
                 parseInstance(instances);
-            } else if (parser.getName().equals("session")) {
+            } else if ("session".equals(tagName)) {
                 parseSessionData(data);
-            } else if (parser.getName().equals("entity") || parser.getName().equals("details")) {
+            } else if ("entity".equals(tagName) || "details".equals(tagName)) {
                 throw new InvalidStructureException("Incompatible CaseXML 1.0 elements detected in <" + block + ">. " +
-                        parser.getName() + " is not a valid construct in 2.0 CaseXML", parser);
-            } else if (parser.getName().equals("stack")) {
+                        tagName + " is not a valid construct in 2.0 CaseXML", parser);
+            } else if ("stack".equals(tagName)) {
                 parseStack(stackOps);
-            } else if (parser.getName().equals("assertions")) {
+            } else if ("assertions".equals(tagName)) {
                 assertions = new AssertionSetParser(parser).parse();
             }
         }
@@ -88,9 +89,10 @@ public class EntryParser extends CommCareElementParser<Entry> {
     private DisplayUnit parseCommandDisplay() throws InvalidStructureException, IOException, XmlPullParserException {
         parser.nextTag();
         DisplayUnit display = null;
-        if (parser.getName().equals("text")) {
+        String tagName = parser.getName();
+        if ("text".equals(tagName)) {
             display = new DisplayUnit(new TextParser(parser).parse(), null, null);
-        } else if (parser.getName().equals("display")) {
+        } else if ("display".equals(tagName)) {
             display = parseDisplayBlock();
             //check that we have text to display;
             if (display.getText() == null) {

--- a/backend/src/org/commcare/xml/EntryParser.java
+++ b/backend/src/org/commcare/xml/EntryParser.java
@@ -121,8 +121,7 @@ public class EntryParser extends CommCareElementParser<Entry> {
     private void parseSessionData(Vector<SessionDatum> data, Vector<RemoteQuery> queries) throws InvalidStructureException, IOException, XmlPullParserException {
         while (nextTagInBlock("session")) {
             if ("query".equals(parser.getName())) {
-                // TODO PLM
-                queries.addElement(new RemoteQuery());
+                queries.addElement(new SessionQueryParser(parser).parse());
             } else {
                 SessionDatumParser parser = new SessionDatumParser(this.parser);
                 data.addElement(parser.parse());

--- a/backend/src/org/commcare/xml/EntryParser.java
+++ b/backend/src/org/commcare/xml/EntryParser.java
@@ -4,8 +4,10 @@ import org.commcare.suite.model.AssertionSet;
 import org.commcare.suite.model.DisplayUnit;
 import org.commcare.suite.model.FormEntry;
 import org.commcare.suite.model.Entry;
+import org.commcare.suite.model.RemoteQuery;
 import org.commcare.suite.model.SessionDatum;
 import org.commcare.suite.model.StackOperation;
+import org.commcare.suite.model.SyncEntry;
 import org.commcare.suite.model.ViewEntry;
 import org.javarosa.core.model.instance.DataInstance;
 import org.javarosa.core.model.instance.ExternalDataInstance;
@@ -21,26 +23,32 @@ import java.util.Vector;
  * @author ctsims
  */
 public class EntryParser extends CommCareElementParser<Entry> {
-    private final boolean isEntry;
+    private static final String FORM_ENTRY_TAG = "entry";
+    private static final String VIEW_ENTRY_TAG = "view";
+    private static final String SYNC_REQUEST_TAG = "sync-request";
+    private final String parserBlockTag;
 
-    private EntryParser(KXmlParser parser, boolean isEntry) {
+    private EntryParser(KXmlParser parser, String parserBlockTag) {
         super(parser);
 
-        this.isEntry = isEntry;
+        this.parserBlockTag = parserBlockTag;
     }
 
     public static EntryParser buildViewParser(KXmlParser parser) {
-        return new EntryParser(parser, false);
+        return new EntryParser(parser, VIEW_ENTRY_TAG);
     }
 
     public static EntryParser buildEntryParser(KXmlParser parser) {
-        return new EntryParser(parser, true);
+        return new EntryParser(parser, FORM_ENTRY_TAG);
+    }
+
+    public static EntryParser buildRemoteSyncParser(KXmlParser parser) {
+        return new EntryParser(parser, SYNC_REQUEST_TAG);
     }
 
     @Override
     public Entry parse() throws InvalidStructureException, IOException, XmlPullParserException {
-        String block = isEntry ? "entry" : "view";
-        this.checkNode(block);
+        this.checkNode(parserBlockTag);
 
         String xFormNamespace = null;
         Vector<SessionDatum> data = new Vector<SessionDatum>();
@@ -50,12 +58,14 @@ public class EntryParser extends CommCareElementParser<Entry> {
         DisplayUnit display = null;
         Vector<StackOperation> stackOps = new Vector<StackOperation>();
         AssertionSet assertions = null;
+        SyncEntry.SyncPost post = null;
+        Vector<RemoteQuery> queries = new Vector<RemoteQuery>();
 
-        while (nextTagInBlock(block)) {
+        while (nextTagInBlock(parserBlockTag)) {
             String tagName = parser.getName();
             if ("form".equals(tagName)) {
-                if (!isEntry) {
-                    throw new InvalidStructureException("<" + block + ">'s cannot specify XForms!!", parser);
+                if (parserBlockTag.equals(VIEW_ENTRY_TAG)) {
+                    throw new InvalidStructureException("<" + parserBlockTag + ">'s cannot specify XForms!!", parser);
                 }
                 xFormNamespace = parser.nextText();
             } else if ("command".equals(tagName)) {
@@ -64,14 +74,16 @@ public class EntryParser extends CommCareElementParser<Entry> {
             } else if ("instance".equals(tagName.toLowerCase())) {
                 parseInstance(instances);
             } else if ("session".equals(tagName)) {
-                parseSessionData(data);
+                parseSessionData(data, queries);
             } else if ("entity".equals(tagName) || "details".equals(tagName)) {
-                throw new InvalidStructureException("Incompatible CaseXML 1.0 elements detected in <" + block + ">. " +
+                throw new InvalidStructureException("Incompatible CaseXML 1.0 elements detected in <" + parserBlockTag + ">. " +
                         tagName + " is not a valid construct in 2.0 CaseXML", parser);
             } else if ("stack".equals(tagName)) {
                 parseStack(stackOps);
             } else if ("assertions".equals(tagName)) {
                 assertions = new AssertionSetParser(parser).parse();
+            } else if ("post".equals(tagName)) {
+                post = parsePost();
             }
         }
 
@@ -79,11 +91,15 @@ public class EntryParser extends CommCareElementParser<Entry> {
             throw new InvalidStructureException("<entry> block must define display text details", parser);
         }
 
-        if (isEntry) {
+        if (FORM_ENTRY_TAG.equals(parserBlockTag)) {
             return new FormEntry(commandId, display, data, xFormNamespace, instances, stackOps, assertions);
-        } else {
+        } else if (VIEW_ENTRY_TAG.equals(parserBlockTag)) {
             return new ViewEntry(commandId, display, data, instances, stackOps, assertions);
+        } else if (SYNC_REQUEST_TAG.equals(parserBlockTag)) {
+            return new SyncEntry(commandId, display, data, instances, stackOps, assertions, post, queries);
         }
+
+        throw new RuntimeException("Misconfigured entry parser");
     }
 
     private DisplayUnit parseCommandDisplay() throws InvalidStructureException, IOException, XmlPullParserException {
@@ -102,10 +118,15 @@ public class EntryParser extends CommCareElementParser<Entry> {
         return display;
     }
 
-    private void parseSessionData(Vector<SessionDatum> data) throws InvalidStructureException, IOException, XmlPullParserException {
+    private void parseSessionData(Vector<SessionDatum> data, Vector<RemoteQuery> queries) throws InvalidStructureException, IOException, XmlPullParserException {
         while (nextTagInBlock("session")) {
-            SessionDatumParser parser = new SessionDatumParser(this.parser);
-            data.addElement(parser.parse());
+            if ("query".equals(parser.getName())) {
+                // TODO PLM
+                queries.addElement(new RemoteQuery());
+            } else {
+                SessionDatumParser parser = new SessionDatumParser(this.parser);
+                data.addElement(parser.parse());
+            }
         }
     }
 
@@ -120,5 +141,10 @@ public class EntryParser extends CommCareElementParser<Entry> {
         String instanceId = parser.getAttributeValue(null, "id");
         String location = parser.getAttributeValue(null, "src");
         instances.put(instanceId, new ExternalDataInstance(location, instanceId));
+    }
+
+    private SyncEntry.SyncPost parsePost() {
+        // TODO PLM
+        return null;
     }
 }

--- a/backend/src/org/commcare/xml/SessionQueryParser.java
+++ b/backend/src/org/commcare/xml/SessionQueryParser.java
@@ -5,7 +5,6 @@ import org.commcare.suite.model.RemoteQuery;
 import org.javarosa.core.model.instance.TreeReference;
 import org.javarosa.model.xform.XPathReference;
 import org.javarosa.xml.util.InvalidStructureException;
-import org.javarosa.xpath.XPathParseTool;
 import org.kxml2.io.KXmlParser;
 import org.xmlpull.v1.XmlPullParserException;
 
@@ -13,24 +12,30 @@ import java.io.IOException;
 import java.util.Hashtable;
 
 /**
+ * Parse remote query associated with synchronous request suite entries.
+ *
  * @author Phillip Mates (pmates@dimagi.com).
  */
 public class SessionQueryParser extends CommCareElementParser<RemoteQuery> {
-    Hashtable<String, TreeReference> hiddenQueryValues = new Hashtable<String, TreeReference>();
-    Hashtable<String, DisplayUnit> userQueryPrompts = new Hashtable<String, DisplayUnit>();
+    private final Hashtable<String, TreeReference> hiddenQueryValues =
+            new Hashtable<String, TreeReference>();
+    private final Hashtable<String, DisplayUnit> userQueryPrompts =
+            new Hashtable<String, DisplayUnit>();
 
     public SessionQueryParser(KXmlParser parser) {
         super(parser);
     }
 
     @Override
-    public RemoteQuery parse() throws InvalidStructureException, IOException, XmlPullParserException {
+    public RemoteQuery parse()
+            throws InvalidStructureException, IOException, XmlPullParserException {
         this.checkNode("query");
 
         String queryUrl = parser.getAttributeValue(null, "url");
         String queryResultStorageInstance = parser.getAttributeValue(null, "storage-instance");
         if (queryUrl == null || queryResultStorageInstance == null) {
-            throw new InvalidStructureException("<query> element missing 'url' or 'storage-instance' attribute", parser);
+            String errorMsg = "<query> element missing 'url' or 'storage-instance' attribute";
+            throw new InvalidStructureException(errorMsg, parser);
         }
 
         while (nextTagInBlock("query")) {
@@ -45,6 +50,8 @@ public class SessionQueryParser extends CommCareElementParser<RemoteQuery> {
                 userQueryPrompts.put(key, display);
             }
         }
-        return new RemoteQuery(queryUrl, queryResultStorageInstance, hiddenQueryValues, userQueryPrompts);
+
+        return new RemoteQuery(queryUrl, queryResultStorageInstance,
+                hiddenQueryValues, userQueryPrompts);
     }
 }

--- a/backend/src/org/commcare/xml/SessionQueryParser.java
+++ b/backend/src/org/commcare/xml/SessionQueryParser.java
@@ -1,0 +1,44 @@
+package org.commcare.xml;
+
+import org.commcare.suite.model.DisplayUnit;
+import org.commcare.suite.model.RemoteQuery;
+import org.javarosa.core.model.instance.TreeReference;
+import org.javarosa.xml.util.InvalidStructureException;
+import org.javarosa.xpath.XPathParseTool;
+import org.kxml2.io.KXmlParser;
+import org.xmlpull.v1.XmlPullParserException;
+
+import java.io.IOException;
+import java.util.Hashtable;
+
+/**
+ * @author Phillip Mates (pmates@dimagi.com).
+ */
+public class SessionQueryParser extends CommCareElementParser<RemoteQuery> {
+    Hashtable<String, TreeReference> hiddenQueryValues = new Hashtable<String, TreeReference>();
+    Hashtable<String, DisplayUnit> userQueryPrompts = new Hashtable<String, DisplayUnit>();
+
+    public SessionQueryParser(KXmlParser parser) {
+        super(parser);
+    }
+
+    @Override
+    public RemoteQuery parse() throws InvalidStructureException, IOException, XmlPullParserException {
+        this.checkNode("query");
+        String queryUrl = parser.getAttributeValue(null, "url");
+        String queryResultStorageInstance = parser.getAttributeValue(null, "instance");
+        while (nextTagInBlock("query")) {
+            String tagName = parser.getName();
+            if ("hidden".equals(tagName)) {
+                String key = parser.getAttributeValue(null, "key");
+                String ref = parser.getAttributeValue(null, "ref");
+                hiddenQueryValues.put(key, XPathParseTool.parseXPath(ref));
+            } else if ("param".equals(tagName)) {
+                String key = parser.getAttributeValue(null, "key");
+                DisplayUnit display = parseDisplayBlock();
+                userQueryPrompts.put(key, display);
+            }
+        }
+        return new RemoteQuery(queryUrl, queryResultStorageInstance, hiddenQueryValues, userQueryPrompts);
+    }
+}

--- a/backend/src/org/commcare/xml/SessionQueryParser.java
+++ b/backend/src/org/commcare/xml/SessionQueryParser.java
@@ -3,6 +3,7 @@ package org.commcare.xml;
 import org.commcare.suite.model.DisplayUnit;
 import org.commcare.suite.model.RemoteQuery;
 import org.javarosa.core.model.instance.TreeReference;
+import org.javarosa.model.xform.XPathReference;
 import org.javarosa.xml.util.InvalidStructureException;
 import org.javarosa.xpath.XPathParseTool;
 import org.kxml2.io.KXmlParser;
@@ -25,15 +26,20 @@ public class SessionQueryParser extends CommCareElementParser<RemoteQuery> {
     @Override
     public RemoteQuery parse() throws InvalidStructureException, IOException, XmlPullParserException {
         this.checkNode("query");
+
         String queryUrl = parser.getAttributeValue(null, "url");
-        String queryResultStorageInstance = parser.getAttributeValue(null, "instance");
+        String queryResultStorageInstance = parser.getAttributeValue(null, "storage-instance");
+        if (queryUrl == null || queryResultStorageInstance == null) {
+            throw new InvalidStructureException("<query> element missing 'url' or 'storage-instance' attribute", parser);
+        }
+
         while (nextTagInBlock("query")) {
             String tagName = parser.getName();
-            if ("hidden".equals(tagName)) {
+            if ("data".equals(tagName)) {
                 String key = parser.getAttributeValue(null, "key");
                 String ref = parser.getAttributeValue(null, "ref");
-                hiddenQueryValues.put(key, XPathParseTool.parseXPath(ref));
-            } else if ("param".equals(tagName)) {
+                hiddenQueryValues.put(key, XPathReference.getPathExpr(ref).getReference());
+            } else if ("prompt".equals(tagName)) {
                 String key = parser.getAttributeValue(null, "key");
                 DisplayUnit display = parseDisplayBlock();
                 userQueryPrompts.put(key, display);

--- a/backend/src/org/commcare/xml/SuiteParser.java
+++ b/backend/src/org/commcare/xml/SuiteParser.java
@@ -6,6 +6,7 @@ import org.commcare.suite.model.Detail;
 import org.commcare.suite.model.Entry;
 import org.commcare.suite.model.Menu;
 import org.commcare.suite.model.Suite;
+import org.commcare.suite.model.SyncEntry;
 import org.javarosa.core.model.instance.FormInstance;
 import org.javarosa.core.services.storage.IStorageUtilityIndexed;
 import org.javarosa.core.services.storage.StorageFullException;
@@ -67,6 +68,8 @@ public class SuiteParser extends ElementParser<Suite> {
         int version = Integer.parseInt(sVersion);
         Hashtable<String, Detail> details = new Hashtable<String, Detail>();
         Hashtable<String, Entry> entries = new Hashtable<String, Entry>();
+        Hashtable<String, SyncEntry> syncRequests = new Hashtable<String, SyncEntry>();
+
         Vector<Menu> menus = new Vector<Menu>();
 
         try {
@@ -83,6 +86,9 @@ public class SuiteParser extends ElementParser<Suite> {
                     } else if (parser.getName().toLowerCase().equals("view")) {
                         Entry e = EntryParser.buildViewParser(parser).parse();
                         entries.put(e.getCommandId(), e);
+                    } else if (parser.getName().toLowerCase().equals("sync-request")) {
+                        SyncEntry syncEntry = (SyncEntry)EntryParser.buildRemoteSyncParser(parser).parse();
+                        syncRequests.put(syncEntry.getCommandId(), syncEntry);
                     } else if (parser.getName().toLowerCase().equals("locale")) {
                         String localeKey = parser.getAttributeValue(null, "language");
                         //resource def

--- a/tests/resources/app_structure/suite.xml
+++ b/tests/resources/app_structure/suite.xml
@@ -61,6 +61,43 @@
       <datum id="case_id" nodeset="instance('casedb')/casedb/case[@case_type='test_case'][@status='open']" value="./@case_id" detail-select="m0_case_short" detail-confirm="m0_case_long"/>
     </session>
   </entry>
+
+  <sync-request>
+    <post url="fake.com/claim_patient/">
+      <data key="selected_name" ref="instance('patients')/case[@case_type='test_case'][@status='open'][0]/name"/>
+      <data key="selected_case_id" ref="instance('patients')/case[@case_type='test_case'][@status='open'][0]/@case_id"/>
+    </post>
+    <instance id="casedb" src="jr://instance/casedb"/>
+    <command id="patient-search">
+      <display>
+        <text>Global search for person</text>
+      </display>
+    </command>
+    <session>
+      <query url="fake.com/patient_search/" storage-instance="patients">
+        <data key="device_id" ref="instance('session')/session/data/uuid"/>
+        <data key="device_case_count" ref="instance('session')/session/data/case_count"/>
+        <prompt key="name">
+          <display>
+            <text>Input patient name</text>
+          </display>
+        </prompt>
+        <prompt key="patient_id">
+          <display>
+            <text>Input patient id</text>
+          </display>
+        </prompt>
+      </query>
+      <datum id="case_id" nodeset="instance('patients')/case[@case_type='geriatric'][@status='open']" value="./@case_id" detail-select="m0_case_short" detail-confirm="m0_case_long"/>
+    </session>
+    <stack>
+      <push>
+        <command value="'m1-f0'"/>
+        <datum id="calculated_data" value="'claimed'"/>
+      </push>
+    </stack>
+  </sync-request>
+
   <menu id="m0">
     <text>Menu</text>
     <command id="m0-f0"/>


### PR DESCRIPTION
Add parser for synchronous request. 

Synchronous requests will be used to claim cases from the server in a synchronous transaction.

Example suite xml entry:
```
<sync-request>
    <post url="fake.com/claim_patient/">
      <data key="selected_name" ref="instance('patients')/case[@case_type='test_case'][@status='open'][0]/name"/>
      <data key="selected_case_id" ref="instance('patients')/case[@case_type='test_case'][@status='open'][0]/@case_id"/>
    </post>
    <instance id="casedb" src="jr://instance/casedb"/>
    <command id="patient-search">
      <display>
        <text>Global search for person</text>
      </display>
    </command>
    <session>
      <query url="fake.com/patient_search/" storage-instance="patients">
        <data key="device_id" ref="instance('session')/session/data/uuid"/>
        <data key="device_case_count" ref="instance('session')/session/data/case_count"/>
        <prompt key="name">
          <display>
            <text>Input patient name</text>
          </display>
        </prompt>
        <prompt key="patient_id">
          <display>
            <text>Input patient id</text>
          </display>
        </prompt>
      </query>
      <datum id="case_id" nodeset="instance('patients')/case[@case_type='geriatric'][@status='open']" value="./@case_id" detail-select="m0_case_short" detail-confirm="m0_case_long"/>
    </session>
    <stack>
      <push>
        <command value="'m1-f0'"/>
        <datum id="calculated_data" value="'claimed'"/>
      </push>
    </stack>
  </sync-request>
```