### PR TITLE
Allow graph apps to be installed by commcare CLI

### DIFF
--- a/backend/src/org/commcare/xml/DetailParser.java
+++ b/backend/src/org/commcare/xml/DetailParser.java
@@ -232,6 +232,6 @@ public class DetailParser extends CommCareElementParser<Detail> {
     }
 
     protected GraphParser getGraphParser() {
-        return new GraphParser(parser);
+        return new DummyGraphParser(parser);
     }
 }

--- a/backend/src/org/commcare/xml/DetailParser.java
+++ b/backend/src/org/commcare/xml/DetailParser.java
@@ -148,10 +148,6 @@ public class DetailParser extends CommCareElementParser<Detail> {
                     parser.nextTag();
                     DetailTemplate template;
                     if (form.equals("graph")) {
-                        GraphParser gp = getGraphParser();
-                        if (gp == null) {
-                            throw new InvalidStructureException("No graph parser available", parser);
-                        }
                         template = getGraphParser().parse();
                     } else if (form.equals("callout")) {
                         template = new CalloutParser(parser).parse();
@@ -236,6 +232,6 @@ public class DetailParser extends CommCareElementParser<Detail> {
     }
 
     protected GraphParser getGraphParser() {
-        return null;
+        return new GraphParser(parser);
     }
 }

--- a/backend/src/org/commcare/xml/DummyGraphParser.java
+++ b/backend/src/org/commcare/xml/DummyGraphParser.java
@@ -1,0 +1,46 @@
+package org.commcare.xml;
+
+import org.commcare.suite.model.DetailTemplate;
+import org.javarosa.core.model.condition.EvaluationContext;
+import org.javarosa.core.util.externalizable.DeserializationException;
+import org.javarosa.core.util.externalizable.Externalizable;
+import org.javarosa.core.util.externalizable.PrototypeFactory;
+import org.javarosa.xml.util.InvalidStructureException;
+import org.kxml2.io.KXmlParser;
+import org.xmlpull.v1.XmlPullParserException;
+
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+
+public class DummyGraphParser extends GraphParser {
+    public DummyGraphParser(KXmlParser parser) {
+        super(parser);
+    }
+
+    @Override
+    public DetailTemplate parse() throws InvalidStructureException, IOException, XmlPullParserException {
+        skipBlock("graph");
+        return new DummyGraphDetailTemplate();
+    }
+
+    public static class DummyGraphDetailTemplate implements  DetailTemplate, Externalizable {
+        public DummyGraphDetailTemplate() {
+        }
+
+        @Override
+        public Object evaluate(EvaluationContext context) {
+            return "graph";
+        }
+
+        @Override
+        public void readExternal(DataInputStream in, PrototypeFactory pf) throws IOException, DeserializationException {
+
+        }
+
+        @Override
+        public void writeExternal(DataOutputStream out) throws IOException {
+
+        }
+    }
+}

--- a/backend/src/org/commcare/xml/GraphParser.java
+++ b/backend/src/org/commcare/xml/GraphParser.java
@@ -1,17 +1,11 @@
 package org.commcare.xml;
 
 import org.commcare.suite.model.DetailTemplate;
-import org.javarosa.core.model.condition.EvaluationContext;
-import org.javarosa.core.util.externalizable.DeserializationException;
-import org.javarosa.core.util.externalizable.Externalizable;
-import org.javarosa.core.util.externalizable.PrototypeFactory;
 import org.javarosa.xml.ElementParser;
 import org.javarosa.xml.util.InvalidStructureException;
 import org.kxml2.io.KXmlParser;
 import org.xmlpull.v1.XmlPullParserException;
 
-import java.io.DataInputStream;
-import java.io.DataOutputStream;
 import java.io.IOException;
 
 /**
@@ -19,34 +13,10 @@ import java.io.IOException;
  *
  * @author jschweers
  */
-public class GraphParser extends ElementParser<DetailTemplate> {
+public abstract class GraphParser extends ElementParser<DetailTemplate> {
     public GraphParser(KXmlParser parser) {
         super(parser);
     }
 
-    @Override
-    public DetailTemplate parse() throws InvalidStructureException, IOException, XmlPullParserException {
-        skipBlock("graph");
-        return new DummyGraphDetailTemplate();
-    }
-
-    public static class DummyGraphDetailTemplate implements  DetailTemplate, Externalizable {
-        public DummyGraphDetailTemplate() {
-        }
-
-        @Override
-        public Object evaluate(EvaluationContext context) {
-            return "graph";
-        }
-
-        @Override
-        public void readExternal(DataInputStream in, PrototypeFactory pf) throws IOException, DeserializationException {
-
-        }
-
-        @Override
-        public void writeExternal(DataOutputStream out) throws IOException {
-
-        }
-    }
+    public abstract DetailTemplate parse() throws InvalidStructureException, IOException, XmlPullParserException;
 }

--- a/backend/src/org/commcare/xml/GraphParser.java
+++ b/backend/src/org/commcare/xml/GraphParser.java
@@ -1,15 +1,22 @@
 package org.commcare.xml;
 
 import org.commcare.suite.model.DetailTemplate;
+import org.javarosa.core.model.condition.EvaluationContext;
+import org.javarosa.core.util.externalizable.DeserializationException;
+import org.javarosa.core.util.externalizable.Externalizable;
+import org.javarosa.core.util.externalizable.PrototypeFactory;
 import org.javarosa.xml.ElementParser;
 import org.javarosa.xml.util.InvalidStructureException;
 import org.kxml2.io.KXmlParser;
 import org.xmlpull.v1.XmlPullParserException;
 
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
 import java.io.IOException;
 
-/*
+/**
  * Parser for a <graph> element, typically used as a detail field's template.
+ *
  * @author jschweers
  */
 public class GraphParser extends ElementParser<DetailTemplate> {
@@ -17,11 +24,29 @@ public class GraphParser extends ElementParser<DetailTemplate> {
         super(parser);
     }
 
-    /*
-     * (non-Javadoc)
-     * @see org.javarosa.xml.ElementParser#parse()
-     */
+    @Override
     public DetailTemplate parse() throws InvalidStructureException, IOException, XmlPullParserException {
-        throw new InvalidStructureException("Unable to parse graph", parser);
+        skipBlock("graph");
+        return new DummyGraphDetailTemplate();
+    }
+
+    public static class DummyGraphDetailTemplate implements  DetailTemplate, Externalizable {
+        public DummyGraphDetailTemplate() {
+        }
+
+        @Override
+        public Object evaluate(EvaluationContext context) {
+            return "graph";
+        }
+
+        @Override
+        public void readExternal(DataInputStream in, PrototypeFactory pf) throws IOException, DeserializationException {
+
+        }
+
+        @Override
+        public void writeExternal(DataOutputStream out) throws IOException {
+
+        }
     }
 }


### PR DESCRIPTION
Currently, if you run the commcare cli on apps that have graphs in them it crashes on startup. Now it only crashes if you to load a view with a graph in it.