### PR TITLE
Warn cli user when username/pw is incorrect

### DIFF
--- a/util/src/org/commcare/util/cli/ApplicationHost.java
+++ b/util/src/org/commcare/util/cli/ApplicationHost.java
@@ -398,6 +398,11 @@ public class ApplicationHost {
             URL url = new URL(otaRestoreURL);
             HttpURLConnection conn = (HttpURLConnection)url.openConnection();
 
+            if (conn.getResponseCode() == HttpURLConnection.HTTP_UNAUTHORIZED) {
+                System.out.println("\nInvalid username or password!");
+                System.exit(-1);
+            }
+
             System.out.println("Restoring user " + username + " to domain " + domain);
 
             ParseUtils.parseIntoSandbox(new BufferedInputStream(conn.getInputStream()), mSandbox);


### PR DESCRIPTION
Tell CLI users when they provide a bad username or password.

Still lags forever with weird auth redirects, but at least now it tells you why things didn't work out.

http://manage.dimagi.com/default.asp?188523