### PR TITLE
Prevent empty case_name in case create block

### DIFF
--- a/backend/src/org/commcare/xml/CaseXmlParser.java
+++ b/backend/src/org/commcare/xml/CaseXmlParser.java
@@ -100,6 +100,9 @@ public class CaseXmlParser extends TransactionParser<Case> {
                 if (data[0] == null || data[2] == null) {
                     throw new InvalidStructureException("One of [case_type, case_name] is missing for case <create> with ID: " + caseId, parser);
                 }
+                if ("".equals(data[2])) {
+                    throw new InvalidStructureException("<case_name> for case <create> with ID: '" + caseId + "' must not be empty" + caseId, parser);
+                }
                 boolean overriden = false;
                 //CaseXML Block is Valid. If we're on loose tolerance, first check if the case exists
                 if (acceptCreateOverwrites) {

--- a/tests/resources/case_parse/case_create_broken_no_casename.xml
+++ b/tests/resources/case_parse/case_create_broken_no_casename.xml
@@ -1,0 +1,22 @@
+<OpenRosaResponse>
+    <message nature="ota_restore_success">Successfully restored account test!</message>
+    <Sync xmlns="http://commcarehq.org/sync">
+        <restore_id>sync_token_a</restore_id>
+    </Sync>
+    <Registration xmlns="http://openrosa.org/user/registration">
+        <username>test</username>
+        <password>sha1$60441$53cf77c2ac3608a944db96af177a6dfe1579e4ba</password>
+        <uuid>test_example</uuid>
+        <date>2012-04-30</date>
+    </Registration>
+
+    <case case_id="123"
+          date_modified="2014-08-04T21:09:07.000000Z" user_id="test_example"
+          xmlns="http://commcarehq.org/case/transaction/v2">
+        <create>
+            <case_type>retain_test</case_type>
+            <case_name/>
+            <owner_id>test_example</owner_id>
+        </create>
+    </case>
+</OpenRosaResponse>

--- a/tests/resources/ipm_restore.xml
+++ b/tests/resources/ipm_restore.xml
@@ -279,7 +279,7 @@
           user_id="" xmlns="http://commcarehq.org/case/transaction/v2">
         <create>
             <case_type>user-owner-mapping-case</case_type>
-            <case_name/>
+            <case_name>Will Rules</case_name>
             <owner_id>a8f5a98c4ce767c35b9132bc75eb225c</owner_id>
         </create>
         <update>

--- a/tests/test/org/commcare/cases/test/BadCaseXMLTests.java
+++ b/tests/test/org/commcare/cases/test/BadCaseXMLTests.java
@@ -42,4 +42,14 @@ public class BadCaseXMLTests {
             Assert.assertEquals("Case XML with invalid index not have created a case record", sandbox.getCaseStorage().getNumRecords(), 0);
         }
     }
+
+    @Test(expected = InvalidStructureException.class)
+    public void testNoCaseName() throws Exception {
+        try {
+            ParseUtils.parseIntoSandbox(this.getClass().getResourceAsStream("/case_parse/case_create_broken_no_casename.xml"), sandbox, true);
+        } finally {
+            // Ensure we didn't make a case entry for the bad case
+            Assert.assertEquals("Case XML with no name should not have created a case record", sandbox.getCaseStorage().getNumRecords(), 0);
+        }
+    }
 }


### PR DESCRIPTION
Blindly implementing constraint to prevent `case_name` from being empty in a case `<create>` block. Please confirm that this looks like the correct approach.

Addresses this backlog ticket: http://manage.dimagi.com/default.asp?34579