### PR TITLE
Parse empty fixtures correctly: don't swallow subsequent fixtures

### DIFF
--- a/backend/src/org/commcare/xml/FixtureXmlParser.java
+++ b/backend/src/org/commcare/xml/FixtureXmlParser.java
@@ -50,11 +50,14 @@ public class FixtureXmlParser extends TransactionParser<FormInstance> {
 
         String userId = parser.getAttributeValue(null, "user_id");
 
-        //Get to the data root
-        parser.nextTag();
+        TreeElement root;
+        if (nextTagInBlock("fixture")) {
+            //TODO: We need to overwrite any matching records here.
+            root = new TreeElementParser(parser, 0, fixtureId).parse();
+        } else {
+            root = new TreeElement();
+        }
 
-        //TODO: We need to overwrite any matching records here.
-        TreeElement root = new TreeElementParser(parser, 0, fixtureId).parse();
         FormInstance instance = new FormInstance(root, fixtureId);
 
         //This is a terrible hack and clayton should feeel terrible about it

--- a/backend/src/org/commcare/xml/FixtureXmlParser.java
+++ b/backend/src/org/commcare/xml/FixtureXmlParser.java
@@ -51,12 +51,12 @@ public class FixtureXmlParser extends TransactionParser<FormInstance> {
         String userId = parser.getAttributeValue(null, "user_id");
 
         TreeElement root;
-        if (nextTagInBlock("fixture")) {
-            //TODO: We need to overwrite any matching records here.
-            root = new TreeElementParser(parser, 0, fixtureId).parse();
-        } else {
-            root = new TreeElement();
+        if (!nextTagInBlock("fixture")) {
+            // fixture with no body; don't commit to storage
+            return null;
         }
+        //TODO: We need to overwrite any matching records here.
+        root = new TreeElementParser(parser, 0, fixtureId).parse();
 
         FormInstance instance = new FormInstance(root, fixtureId);
 

--- a/cases/src/org/commcare/cases/instance/CaseChildElement.java
+++ b/cases/src/org/commcare/cases/instance/CaseChildElement.java
@@ -54,7 +54,6 @@ public class CaseChildElement implements AbstractTreeElement<TreeElement> {
         this.mult = TreeReference.INDEX_TEMPLATE;
         this.caseId = null;
 
-        empty = new TreeElement();
         empty = new TreeElement("case");
         empty.setMult(this.mult);
 

--- a/tests/resources/create_case_for_ledger.xml
+++ b/tests/resources/create_case_for_ledger.xml
@@ -17,6 +17,8 @@
         </groups>
     </fixture>
 
+    <fixture id="empty-fixture" user_id="test_example"/>
+
     <case case_id="market_basket"
           date_modified="2014-08-04T21:09:07.000000Z" user_id="test_example"
           xmlns="http://commcarehq.org/case/transaction/v2">


### PR DESCRIPTION
Whenever empty fixtures were encountered they would swallow the rest of the restore file into them.

http://manage.dimagi.com/default.asp?158398

cross-request: https://github.com/dimagi/javarosa/pull/257