### PR TITLE
J2ME Build Fix and Cert Redirect

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@ local.properties
 backend/bin/
 application/bin/
 application/build
+core/bin/
+core/build/
 util/bin
 application/dist
 application/lib

--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ build/
 *.db
 .gradle/
 .idea/
+clean_annotations.sh

--- a/application/build.xml
+++ b/application/build.xml
@@ -181,8 +181,6 @@
                     <parameter name="keep              " value="class org.javarosa.core.model.SubmissionProfile"/>
                     <parameter name="keep                ,              allowShrinking" value="class * extends org.javarosa.core.model.SubmissionProfile"/>
                     <parameter name="keep                  ,                allowShrinking" value="!abstract class * extends org.javarosa.core.model.instance.DataInstance"/>
-                    <parameter name="keep                  ,                 allowShrinking" value="!abstract class * extends org.javarosa.core.model.Action"/>
-                    <parameter name="keep                  ,                  allowShrinking" value="class org.javarosa.core.model.Action"/>
                 </obfuscator>
 
                 <!-- log settings: only use debug setting when the test-property is true -->

--- a/application/build.xml
+++ b/application/build.xml
@@ -181,6 +181,7 @@
                     <parameter name="keep              " value="class org.javarosa.core.model.SubmissionProfile"/>
                     <parameter name="keep                ,              allowShrinking" value="class * extends org.javarosa.core.model.SubmissionProfile"/>
                     <parameter name="keep                  ,                allowShrinking" value="!abstract class * extends org.javarosa.core.model.instance.DataInstance"/>
+                    <parameter name="keep                  ,                 allowShrinking" value="!abstract class * extends org.javarosa.core.model.actions.Action"/>
                 </obfuscator>
 
                 <!-- log settings: only use debug setting when the test-property is true -->

--- a/application/src/org/commcare/midlet/CommCareMidlet.java
+++ b/application/src/org/commcare/midlet/CommCareMidlet.java
@@ -9,6 +9,7 @@ import org.commcare.util.CommCareUtil;
 import org.commcare.util.InitializationListener;
 import org.javarosa.core.services.Logger;
 import org.javarosa.core.services.storage.StorageManager;
+import org.javarosa.service.transport.securehttp.AuthenticatedHttpTransportMessage;
 import org.javarosa.services.transport.TransportService;
 
 import javax.microedition.midlet.MIDlet;
@@ -44,6 +45,7 @@ public class CommCareMidlet extends MIDlet {
      * @see javax.microedition.midlet.MIDlet#startApp()
      */
     protected void startApp() throws MIDletStateChangeException {
+        AuthenticatedHttpTransportMessage.CalloutResolver = this;
         CommCareStatic.init();
         CommCareContext.init(this, new InitializationListener() {
 

--- a/application/src/org/commcare/util/CommCareModule.java
+++ b/application/src/org/commcare/util/CommCareModule.java
@@ -10,6 +10,7 @@ import org.commcare.resources.model.installers.MediaInstaller;
 import org.commcare.resources.model.installers.ProfileInstaller;
 import org.commcare.resources.model.installers.SuiteInstaller;
 import org.commcare.resources.model.installers.XFormInstaller;
+import org.commcare.suite.model.FormEntry;
 import org.commcare.suite.model.Profile;
 import org.commcare.suite.model.PropertySetter;
 import org.commcare.suite.model.Suite;
@@ -35,7 +36,8 @@ public class CommCareModule implements IModule {
                                             MediaInstaller.class.getName(),
                                             XFormInstaller.class.getName(),
                                             Text.class.getName(),
-                                            PropertySetter.class.getName()};
+                                            PropertySetter.class.getName(),
+                                            FormEntry.class.getName()};
         PrototypeManager.registerPrototypes(prototypes);
 
         StorageManager.registerStorage(CommCareContext.STORAGE_TABLE_GLOBAL, Resource.class);

--- a/core/.classpath
+++ b/core/.classpath
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="src" path=""/>
+	<classpathentry combineaccessrules="false" kind="src" path="/javarosa-core"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
+	<classpathentry combineaccessrules="false" kind="src" path="/org.commcare"/>
+	<classpathentry combineaccessrules="false" kind="src" path="/org.commcare.cases"/>
+	<classpathentry kind="output" path="bin"/>
+</classpath>

--- a/core/.project
+++ b/core/.project
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>org.commcare.core</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+	</natures>
+</projectDescription>


### PR DESCRIPTION
Fixes the J2ME build (Serialization issues again)

Adds a platform redirect on J2ME where if an https request has certificate failures, it redirects the user to an optional URL that allows the user to create an exception on the device 

cross-request: https://github.com/dimagi/javarosa/pull/265