### PR TITLE
Cast to entity datum

### DIFF
--- a/application/src/org/commcare/util/CommCareSessionController.java
+++ b/application/src/org/commcare/util/CommCareSessionController.java
@@ -16,6 +16,7 @@ import org.commcare.suite.model.Detail;
 import org.commcare.suite.model.Entry;
 import org.commcare.suite.model.Menu;
 import org.commcare.suite.model.SessionDatum;
+import org.commcare.suite.model.EntityDatum;
 import org.commcare.suite.model.StackOperation;
 import org.commcare.suite.model.Suite;
 import org.commcare.suite.model.Text;
@@ -269,7 +270,7 @@ public class CommCareSessionController {
         //TODO: Stuff can be in more than one suite!!!
         Suite suite = session.getCurrentSuite();
 
-        SessionDatum datum = session.getNeededDatum();
+        EntityDatum datum = (EntityDatum)session.getNeededDatum();
         EvaluationContext context = session.getEvaluationContext(getIif());
 
         //TODO: This should be part of the next/back protocol in the session, not here.


### PR DESCRIPTION
fix following j2me build issue introduced by https://github.com/dimagi/commcare/pull/282

```
 [compiler] Compiling 1130 source files to <http://jenkins.dimagi.com/job/commcare-mobile/ws/application/build/real/Generic/CustomKeys/none/classes>
    [javac] <http://jenkins.dimagi.com/job/commcare-mobile/ws/application/src/org/commcare/util/CommCareSessionController.java>:287: error: cannot find symbol
    [javac]         Detail shortDetail = suite.getDetail(datum.getShortDetail());
    [javac]                                                   ^
    [javac]   symbol:   method getShortDetail()
    [javac]   location: variable datum of type SessionDatum
    [javac] <http://jenkins.dimagi.com/job/commcare-mobile/ws/application/src/org/commcare/util/CommCareSessionController.java>:289: error: cannot find symbol
    [javac]         if (datum.getLongDetail() != null) {
    [javac]                  ^
    [javac]   symbol:   method getLongDetail()
    [javac]   location: variable datum of type SessionDatum
    [javac] <http://jenkins.dimagi.com/job/commcare-mobile/ws/application/src/org/commcare/util/CommCareSessionController.java>:290: error: cannot find symbol
    [javac]             longDetail = suite.getDetail(datum.getLongDetail());
    [javac]                                               ^
    [javac]   symbol:   method getLongDetail()
    [javac]   location: variable datum of type SessionDatum
    [javac] <http://jenkins.dimagi.com/job/commcare-mobile/ws/application/src/org/commcare/util/CommCareSessionController.java>:293: error: cannot find symbol
    [javac]         final NodeEntitySet nes = new NodeEntitySet(datum.getNodeset(), context);
    [javac]                                                          ^
    [javac]   symbol:   method getNodeset()
    [javac]   location: variable datum of type SessionDatum
    [javac] Note: Some input files use unchecked or unsafe operations.
    [javac] Note: Recompile with -Xlint:unchecked for details.
    [javac] 4 errors
```