### PR TITLE
Return true on isView for some FormEntry instances

### DIFF
--- a/backend/src/org/commcare/session/CommCareSession.java
+++ b/backend/src/org/commcare/session/CommCareSession.java
@@ -1,8 +1,8 @@
 package org.commcare.session;
 
 import org.commcare.suite.model.Detail;
-import org.commcare.suite.model.FormEntry;
 import org.commcare.suite.model.Entry;
+import org.commcare.suite.model.FormEntry;
 import org.commcare.suite.model.Menu;
 import org.commcare.suite.model.SessionDatum;
 import org.commcare.suite.model.StackFrameStep;
@@ -784,7 +784,10 @@ public class CommCareSession {
      */
     public boolean isViewCommand(String command) {
         Vector<Entry> entries = this.getEntriesForCommand(command);
-        return entries.elementAt(0).isView();
+        Entry entry = entries.elementAt(0);
+        return entries.size() == 1
+                && entry.isView()
+                && entry.getPostEntrySessionOperations().size() == 0;
     }
 
     public void addExtraToCurrentFrameStep(String key, String value) {

--- a/backend/src/org/commcare/suite/model/Entry.java
+++ b/backend/src/org/commcare/suite/model/Entry.java
@@ -53,6 +53,12 @@ public abstract class Entry implements Externalizable, MenuDisplayable {
     }
 
     public boolean isView() {
+        if (this instanceof FormEntry) {
+            FormEntry formEntry = ((FormEntry)this);
+            // _Looks like_ HQ often sends down <entry> blocks with empty
+            // xform namespaces to represent views.
+            return formEntry.getXFormNamespace() == null;
+        }
         return false;
     }
 


### PR DESCRIPTION
Fix the assumption that `<entry>` is never a view, which I made in https://github.com/dimagi/commcare/pull/242