### PR TITLE
Add relevancy condition to post request

### DIFF
--- a/backend/src/org/commcare/session/CommCareSession.java
+++ b/backend/src/org/commcare/session/CommCareSession.java
@@ -463,7 +463,7 @@ public class CommCareSession {
         }
 
         Entry e = platform.getMenuMap().get(command);
-        if (e.isView()) {
+        if (e.isView() || e.isSync()) {
             return null;
         } else {
             return ((FormEntry)e).getXFormNamespace();

--- a/backend/src/org/commcare/session/CommCareSession.java
+++ b/backend/src/org/commcare/session/CommCareSession.java
@@ -81,7 +81,7 @@ public class CommCareSession {
 
     public CommCareSession(CommCarePlatform platform) {
         this.platform = platform;
-        collectedDatums = new OrderedHashtable<String, String>();
+        this.collectedDatums = new OrderedHashtable<String, String>();
         this.frame = new SessionFrame();
         this.frameStack = new Stack<SessionFrame>();
     }
@@ -189,7 +189,7 @@ public class CommCareSession {
      * @return One of the session SessionFrame.STATE_* strings, or null if
      * the session does not need anything else to proceed
      */
-    public String getNeededData() {
+    public String getNeededData(EvaluationContext evalContext) {
         if (currentCmd == null) {
             return SessionFrame.STATE_COMMAND_ID;
         }
@@ -199,7 +199,9 @@ public class CommCareSession {
 
         if (needDatum != null) {
             return needDatum;
-        } else if (entries.size() == 1 && entries.elementAt(0) instanceof SyncEntry) {
+        } else if (entries.size() == 1
+                && entries.elementAt(0) instanceof SyncEntry
+                && ((SyncEntry)entries.elementAt(0)).getSyncPost().isRelevant(evalContext)) {
             return SessionFrame.STATE_SYNC_REQUEST;
         } else if (entries.size() > 1 || !entries.elementAt(0).getCommandId().equals(currentCmd)) {
             //the only other thing we can need is a form command. If there's
@@ -356,14 +358,14 @@ public class CommCareSession {
         return null;
     }
 
-    public void stepBack() {
+    public void stepBack(EvaluationContext evalContext) {
         // Pop the first thing off of the stack frame, no matter what
         popSessionFrameStack();
 
         // Keep popping things off until the value of needed data indicates that we are back to
         // somewhere where we are waiting for user-provided input
-        while (this.getNeededData() == null ||
-                this.getNeededData().equals(SessionFrame.STATE_DATUM_COMPUTED)) {
+        while (this.getNeededData(evalContext) == null ||
+                this.getNeededData(evalContext).equals(SessionFrame.STATE_DATUM_COMPUTED)) {
             popSessionFrameStack();
         }
     }

--- a/backend/src/org/commcare/session/SessionNavigator.java
+++ b/backend/src/org/commcare/session/SessionNavigator.java
@@ -61,7 +61,7 @@ public class SessionNavigator {
     public void startNextSessionStep() {
         currentSession = responder.getSessionForNavigator();
         ec = responder.getEvalContextForNavigator();
-        String needed = currentSession.getNeededData();
+        String needed = currentSession.getNeededData(ec);
         if (needed == null) {
             readyToProceed();
         } else if (needed.equals(SessionFrame.STATE_COMMAND_ID)) {
@@ -148,6 +148,6 @@ public class SessionNavigator {
     }
 
     public void stepBack() {
-        currentSession.stepBack();
+        currentSession.stepBack(ec);
     }
 }

--- a/backend/src/org/commcare/suite/model/SyncPost.java
+++ b/backend/src/org/commcare/suite/model/SyncPost.java
@@ -5,6 +5,8 @@ import org.javarosa.core.model.condition.EvaluationContext;
 import org.javarosa.core.util.externalizable.DeserializationException;
 import org.javarosa.core.util.externalizable.ExtUtil;
 import org.javarosa.core.util.externalizable.ExtWrapMapPoly;
+import org.javarosa.core.util.externalizable.ExtWrapNullable;
+import org.javarosa.core.util.externalizable.ExtWrapTagged;
 import org.javarosa.core.util.externalizable.Externalizable;
 import org.javarosa.core.util.externalizable.PrototypeFactory;
 import org.javarosa.xpath.expr.XPathExpression;
@@ -23,29 +25,41 @@ import java.util.Hashtable;
  */
 public class SyncPost implements Externalizable {
     private String url;
+    private XPathExpression relevantExpr;
     private Hashtable<String, XPathExpression> params;
 
     @SuppressWarnings("unused")
     public SyncPost() {
     }
 
-    public SyncPost(String url, Hashtable<String, XPathExpression> params) {
+    public SyncPost(String url, XPathExpression relevantExpr,
+                    Hashtable<String, XPathExpression> params) {
         this.url = (url == null) ? "" : url;
         this.params = params;
+        this.relevantExpr = relevantExpr;
     }
 
     public String getUrl() {
         return url;
     }
 
-    public Hashtable<String, String> getEvaluatedParams(EvaluationContext evaluationContext) {
+    public Hashtable<String, String> getEvaluatedParams(EvaluationContext evalContext) {
         Hashtable<String, String> evaluatedParams = new Hashtable<String, String>();
         for(Enumeration en = params.keys(); en.hasMoreElements(); ) {
             String key = (String)en.nextElement();
             evaluatedParams.put(key,
-                    RemoteQuerySessionManager.evalXpathExpression(params.get(key), evaluationContext));
+                    RemoteQuerySessionManager.evalXpathExpression(params.get(key), evalContext));
         }
         return evaluatedParams;
+    }
+
+    public boolean isRelevant(EvaluationContext evalContext) {
+        if (relevantExpr == null) {
+            return true;
+        } else {
+            String result = RemoteQuerySessionManager.evalXpathExpression(relevantExpr, evalContext);
+            return "true".equals(result);
+        }
     }
 
     @Override
@@ -53,11 +67,13 @@ public class SyncPost implements Externalizable {
             throws IOException, DeserializationException {
         params = (Hashtable<String, XPathExpression>)ExtUtil.read(in, new ExtWrapMapPoly(String.class), pf);
         url = ExtUtil.readString(in);
+        relevantExpr = (XPathExpression)ExtUtil.read(in, new ExtWrapNullable(new ExtWrapTagged()), pf);
     }
 
     @Override
     public void writeExternal(DataOutputStream out) throws IOException {
         ExtUtil.write(out, new ExtWrapMapPoly(params));
         ExtUtil.writeString(out, url);
+        ExtUtil.write(out, new ExtWrapNullable(relevantExpr == null ? null : new ExtWrapTagged(relevantExpr)));
     }
 }

--- a/backend/src/org/commcare/xml/EntryParser.java
+++ b/backend/src/org/commcare/xml/EntryParser.java
@@ -105,7 +105,11 @@ public class EntryParser extends CommCareElementParser<Entry> {
         } else if (FORM_ENTRY_TAG.equals(parserBlockTag)) {
             return new FormEntry(commandId, display, data, xFormNamespace, instances, stackOps, assertions);
         } else if (SYNC_REQUEST_TAG.equals(parserBlockTag)) {
-            return new SyncEntry(commandId, display, data, instances, stackOps, assertions, post);
+            if (post == null) {
+                throw new RuntimeException(SYNC_REQUEST_TAG + " must contain a <post> element");
+            } else {
+                return new SyncEntry(commandId, display, data, instances, stackOps, assertions, post);
+            }
         }
 
         throw new RuntimeException("Misconfigured entry parser with unsupported '" + parserBlockTag + "' tag.");

--- a/backend/src/org/commcare/xml/EntryParser.java
+++ b/backend/src/org/commcare/xml/EntryParser.java
@@ -149,6 +149,18 @@ public class EntryParser extends CommCareElementParser<Entry> {
 
     private SyncPost parsePost() throws InvalidStructureException, IOException, XmlPullParserException {
         String url = parser.getAttributeValue(null, "url");
+
+        XPathExpression relevantExpr = null;
+        String relevantExprString = parser.getAttributeValue(null, "relevant");
+        if (relevantExprString != null) {
+            try {
+                relevantExpr = XPathParseTool.parseXPath(relevantExprString);
+            } catch (XPathSyntaxException e) {
+                String messageBase = "'relevant' doesn't contain a valid xpath expression: ";
+                throw new InvalidStructureException(messageBase + relevantExprString, parser);
+            }
+        }
+
         Hashtable<String, XPathExpression> postData = new Hashtable<String, XPathExpression>();
         while (nextTagInBlock("post")) {
             if ("data".equals(parser.getName())) {
@@ -158,13 +170,13 @@ public class EntryParser extends CommCareElementParser<Entry> {
                     postData.put(parser.getAttributeValue(null, "key"), expr);
                 } catch (XPathSyntaxException e) {
                     String errorMessage = "'ref' value is not a valid xpath expression: " + refString;
-                    throw new InvalidStructureException(errorMessage, this.parser);
+                    throw new InvalidStructureException(errorMessage, parser);
                 }
             } else {
                 throw new InvalidStructureException("Expected <data> element in a <post> structure.",
                         parser);
             }
         }
-        return new SyncPost(url, postData);
+        return new SyncPost(url, relevantExpr, postData);
     }
 }

--- a/tests/resources/session-tests-template/suite.xml
+++ b/tests/resources/session-tests-template/suite.xml
@@ -104,12 +104,14 @@
   </entry>
 
   <sync-request>
-    <post url="fake.com/claim_patient/">
+    <post url="fake.com/claim_patient/"
+          relevant="true()">
       <data key="selected_name" ref="instance('patients')/case/name"/>
       <data key="selected_case_id" ref="instance('patients')/case/@case_id"/>
     </post>
     <instance id="casedb" src="jr://instance/casedb"/>
     <instance id="session" src="jr://instance/session"/>
+    <relevant value="count(instance('casedb')/case[@case_id=instance('session')/session/data/case_id]) &gt; 0"/>
     <command id="patient-search">
       <display>
         <text>Global search for person</text>
@@ -143,6 +145,26 @@
   <sync-request>
     <post url="fake.com/claim_patient/"/>
     <command id="empty-sync-request">
+      <display>
+        <text>Global search for person</text>
+      </display>
+    </command>
+    <session/>
+  </sync-request>
+
+  <sync-request>
+    <post url="fake.com/claim_patient/" relevant="false()"/>
+    <command id="irrelevant-sync-request">
+      <display>
+        <text>Global search for person</text>
+      </display>
+    </command>
+    <session/>
+  </sync-request>
+
+  <sync-request>
+    <post url="fake.com/claim_patient/" relevant="true()"/>
+    <command id="relevant-sync-request">
       <display>
         <text>Global search for person</text>
       </display>

--- a/tests/resources/session-tests-template/suite.xml
+++ b/tests/resources/session-tests-template/suite.xml
@@ -105,13 +105,12 @@
 
   <sync-request>
     <post url="fake.com/claim_patient/"
-          relevant="true()">
-      <data key="selected_name" ref="instance('patients')/case/name"/>
-      <data key="selected_case_id" ref="instance('patients')/case/@case_id"/>
+          relevant="count(instance('casedb')/casedb/case[@case_id=instance('session')/session/data/case_id]) = 0">
+      <data key="selected_case_id" ref="instance('session')/session/data/case_id"/>
+      <data key="selected_name" ref="instance('patients')/case[@case_id=instance('session')/session/data/case_id]/name"/>
     </post>
     <instance id="casedb" src="jr://instance/casedb"/>
     <instance id="session" src="jr://instance/session"/>
-    <relevant value="count(instance('casedb')/case[@case_id=instance('session')/session/data/case_id]) &gt; 0"/>
     <command id="patient-search">
       <display>
         <text>Global search for person</text>
@@ -120,7 +119,6 @@
     <session>
       <query url="fake.com/patient_search/" storage-instance="patients">
         <data key="device_id" ref="instance('session')/session/data/uuid"/>
-        <data key="device_case_count" ref="instance('session')/session/data/case_count"/>
         <prompt key="name">
           <display>
             <text>Input patient name</text>
@@ -132,7 +130,7 @@
           </display>
         </prompt>
       </query>
-      <datum id="case_id" nodeset="instance('patients')/case[@case_type='geriatric'][@status='open']" value="./@case_id" detail-select="m0_case_short" detail-confirm="m0_case_long"/>
+      <datum id="case_id" nodeset="instance('patients')/case" value="./@case_id" detail-select="m0_case_short" detail-confirm="m0_case_long"/>
     </session>
     <stack>
       <create>

--- a/tests/test/org/commcare/backend/session/test/BasicSessionNavigationTests.java
+++ b/tests/test/org/commcare/backend/session/test/BasicSessionNavigationTests.java
@@ -1,10 +1,12 @@
 package org.commcare.backend.session.test;
 
+import org.commcare.test.utilities.CaseTestUtils;
 import org.commcare.test.utilities.MockApp;
 import org.commcare.session.SessionFrame;
 import org.commcare.util.mocks.SessionWrapper;
 import org.javarosa.core.model.instance.ExternalDataInstance;
 import org.javarosa.core.model.instance.TreeElement;
+import org.javarosa.xpath.parser.XPathSyntaxException;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -143,6 +145,27 @@ public class BasicSessionNavigationTests {
         Assert.assertEquals(session.getNeededData(), SessionFrame.STATE_SYNC_REQUEST);
     }
 
+    /**
+     * Try selecting case already in local case db
+     */
+    @Test
+    public void testStepToIrrelevantSyncRequest() {
+        session.setCommand("patient-search");
+        Assert.assertEquals(session.getNeededData(), SessionFrame.STATE_QUERY_REQUEST);
+
+        TreeElement data = SessionStackTests.buildExampleInstanceRoot("some_patient_id");
+        session.setQueryDatum(ExternalDataInstance.buildFromRemote("patients", data));
+
+        // case_id
+        Assert.assertEquals(session.getNeededData(), SessionFrame.STATE_DATUM_VAL);
+        Assert.assertEquals(session.getNeededDatum().getDataId(), "case_id");
+        // select case present in user_restore
+        session.setDatum("case_id", "case_one");
+
+        // assert that relevancy condition of post request is false
+        Assert.assertEquals(session.getNeededData(), null);
+    }
+
     @Test
     public void testInvokeEmptySyncRequest() {
         SessionWrapper session = mApp.getSession();
@@ -154,9 +177,9 @@ public class BasicSessionNavigationTests {
     @Test
     public void testStepToSyncRequestRelevancy() {
         session.setCommand("irrelevant-sync-request");
-        Assert.assertEquals(session.getNeededData(session.getEvaluationContext()), null);
+        Assert.assertEquals(session.getNeededData(), null);
 
         session.setCommand("relevant-sync-request");
-        Assert.assertEquals(session.getNeededData(session.getEvaluationContext()), SessionFrame.STATE_SYNC_REQUEST);
+        Assert.assertEquals(session.getNeededData(), SessionFrame.STATE_SYNC_REQUEST);
     }
 }

--- a/tests/test/org/commcare/backend/session/test/BasicSessionNavigationTests.java
+++ b/tests/test/org/commcare/backend/session/test/BasicSessionNavigationTests.java
@@ -19,16 +19,16 @@ import org.junit.Test;
 public class BasicSessionNavigationTests {
 
     MockApp mApp;
+    SessionWrapper session;
 
     @Before
     public void setUp() throws Exception {
         mApp = new MockApp("/session-tests-template/");
+        session = mApp.getSession();
     }
 
     @Test
     public void testNeedsCommandFirst() {
-        SessionWrapper session = mApp.getSession();
-
         // Before anything is done in the session, should need a command
         Assert.assertEquals(session.getNeededData(), SessionFrame.STATE_COMMAND_ID);
 
@@ -57,8 +57,6 @@ public class BasicSessionNavigationTests {
 
     @Test
     public void testNeedsCaseFirst() {
-        SessionWrapper session = mApp.getSession();
-
         // Before anything is done in the session, should need a command
         Assert.assertEquals(session.getNeededData(), SessionFrame.STATE_COMMAND_ID);
 
@@ -78,7 +76,6 @@ public class BasicSessionNavigationTests {
 
     @Test
     public void testStepBackBasic() {
-        SessionWrapper session = mApp.getSession();
         Assert.assertEquals(session.getNeededData(), SessionFrame.STATE_COMMAND_ID);
         session.setCommand("m1");
         Assert.assertEquals(session.getNeededData(), SessionFrame.STATE_COMMAND_ID);
@@ -96,7 +93,6 @@ public class BasicSessionNavigationTests {
 
     @Test
     public void testStepBackWithExtraValue() {
-        SessionWrapper session = mApp.getSession();
         Assert.assertEquals(session.getNeededData(), SessionFrame.STATE_COMMAND_ID);
         session.setCommand("m1");
         Assert.assertEquals(session.getNeededData(), SessionFrame.STATE_COMMAND_ID);
@@ -116,7 +112,6 @@ public class BasicSessionNavigationTests {
 
     @Test
     public void testStepBackWithComputedDatum() {
-        SessionWrapper session = mApp.getSession();
         Assert.assertEquals(session.getNeededData(), SessionFrame.STATE_COMMAND_ID);
         session.setCommand("m0");
         Assert.assertEquals(session.getNeededData(), SessionFrame.STATE_COMMAND_ID);
@@ -133,8 +128,6 @@ public class BasicSessionNavigationTests {
 
     @Test
     public void testStepToSyncRequest() {
-        SessionWrapper session = mApp.getSession();
-
         session.setCommand("patient-search");
         Assert.assertEquals(session.getNeededData(), SessionFrame.STATE_QUERY_REQUEST);
 
@@ -156,5 +149,14 @@ public class BasicSessionNavigationTests {
 
         session.setCommand("empty-sync-request");
         Assert.assertEquals(session.getNeededData(), SessionFrame.STATE_SYNC_REQUEST);
+    }
+
+    @Test
+    public void testStepToSyncRequestRelevancy() {
+        session.setCommand("irrelevant-sync-request");
+        Assert.assertEquals(session.getNeededData(session.getEvaluationContext()), null);
+
+        session.setCommand("relevant-sync-request");
+        Assert.assertEquals(session.getNeededData(session.getEvaluationContext()), SessionFrame.STATE_SYNC_REQUEST);
     }
 }

--- a/tests/test/org/commcare/backend/session/test/SessionStackTests.java
+++ b/tests/test/org/commcare/backend/session/test/SessionStackTests.java
@@ -272,6 +272,7 @@ public class SessionStackTests {
             ExprEvalUtils.xpathEval(session.getEvaluationContext(), xpath);
             Assert.fail("instance('patients') should not be available");
         } catch (XPathMissingInstanceException e) {
+            // expected
         }
     }
 }

--- a/util/src/org/commcare/util/cli/ApplicationHost.java
+++ b/util/src/org/commcare/util/cli/ApplicationHost.java
@@ -168,7 +168,7 @@ public class ApplicationHost {
                         }
 
                         if (input.equals(":back")) {
-                            mSession.stepBack();
+                            mSession.stepBack(mSession.getEvaluationContext());
                             s = getNextScreen();
                             continue;
                         }
@@ -233,7 +233,7 @@ public class ApplicationHost {
                     finishSession();
                     return true;
                 } else if (player.getExecutionResult() == XFormPlayer.FormResult.Cancelled) {
-                    mSession.stepBack();
+                    mSession.stepBack(mSession.getEvaluationContext());
                     s = getNextScreen();
                 } else {
                     //Handle this later
@@ -295,7 +295,7 @@ public class ApplicationHost {
     }
 
     private Screen getNextScreen() {
-        String next = mSession.getNeededData();
+        String next = mSession.getNeededData(mSession.getEvaluationContext());
 
         if (next == null) {
             //XFORM TIME!
@@ -308,7 +308,7 @@ public class ApplicationHost {
             computeDatum();
             return getNextScreen();
         }
-        throw new RuntimeException("Unexpected Frame Request: " + mSession.getNeededData());
+        throw new RuntimeException("Unexpected Frame Request: " + next);
     }
 
     private void computeDatum() {

--- a/util/src/org/commcare/util/mocks/SessionWrapper.java
+++ b/util/src/org/commcare/util/mocks/SessionWrapper.java
@@ -59,4 +59,12 @@ public class SessionWrapper extends CommCareSession {
     public void setComputedDatum() {
         setComputedDatum(getEvaluationContext());
     }
+
+    public String getNeededData() {
+        return super.getNeededData(getEvaluationContext());
+    }
+
+    public void stepBack() {
+        super.stepBack(getEvaluationContext());
+    }
 }


### PR DESCRIPTION
Add `relevant="some_xpath_expr"` to the `post` tag of a sync request. The relevancy condition is checked before making the post request. This allows mobile to check if the case is already owned by the user before claiming it on HQ. Doing this check on the server side is much more difficult.

cross-request: https://github.com/dimagi/commcare-odk/pull/1288

example:
```
 <sync-request>
    <post url="https://www.fake.com/claim_patient/"
          relevant="count(instance('casedb')/casedb/case[@case_id=instance('session')/session/data/case_id]) = 0">
      <data key="selected_case_id" ref="instance('session')/session/data/case_id"/>
    </post>
    <command id="patient-search">
      <display>
        <text>Global search for person</text>
      </display>
    </command>
    <instance id="session" src="jr://instance/session"/>
    <instance id="casedb" src="jr://instance/casedb"/>
    <session>
      <query url="https://www.fake.com/patient_search/" storage-instance="patients">
        <data key="device_id" ref="instance('session')/session/context/deviceid"/>
        <prompt key="name">
          <display>
            <text>
              <locale id="query.name"/>
            </text>
          </display>
        </prompt>
        <prompt key="patient_id">
          <display>
            <text>
              <locale id="query.id"/>
            </text>
          </display>
        </prompt>
      </query>
      <datum id="case_id" nodeset="instance('patients')/patients/patient" value="./id" detail-select="patient_short" detail-confirm="patient_long"/>
    </session>
    <stack>
      <create>
        <command value="'m1'"/>
        <datum id="case_id" value="instance('session')/session/data/case_id"/>
      </create>
    </stack>
  </sync-request>
```