### PR TITLE
Installation and update performance improvements

### DIFF
--- a/backend/src/org/commcare/resources/ResourceManager.java
+++ b/backend/src/org/commcare/resources/ResourceManager.java
@@ -233,8 +233,7 @@ public class ResourceManager {
                 upgradeTable.destroy();
 
                 Logger.log("Resource", "Clearing out old resources");
-                tempTable.flagForDeletions(masterTable);
-                tempTable.completeUninstall();
+                tempTable.uninstall(masterTable);
             } finally {
                 if (!upgradeSuccess) {
                     repair();

--- a/backend/src/org/commcare/resources/model/ResourceTable.java
+++ b/backend/src/org/commcare/resources/model/ResourceTable.java
@@ -608,7 +608,9 @@ public class ResourceTable {
         // Upgrade elements should result in their counterpart in this table
         // being unstaged (which can be reverted).
 
-        for (Resource r : incoming.getResources()) {
+
+        for (IStorageIterator it = incoming.storage.iterate(); it.hasMore(); ) {
+            Resource r = (Resource)it.nextRecord();
             Resource peer = getResourceWithId(r.getResourceId());
             if (peer == null) {
                 // no corresponding resource in this table; use incoming
@@ -667,7 +669,8 @@ public class ResourceTable {
      */
     public void uninstall(ResourceTable replacement) {
         cleanup();
-        for (Resource r : getResources()) {
+        for (IStorageIterator it = storage.iterate(); it.hasMore(); ) {
+            Resource r = (Resource)it.nextRecord();
             if (replacement.getResourceWithId(r.getResourceId()) == null ||
                     r.getStatus() == Resource.RESOURCE_STATUS_UNSTAGED) {
                 // No entry in 'replacement' so it's no longer relevant
@@ -740,7 +743,8 @@ public class ResourceTable {
         }
 
         // Copy over all of our resources to the new table
-        for (Resource r : this.getResources()) {
+        for (IStorageIterator it = storage.iterate(); it.hasMore(); ) {
+            Resource r = (Resource)it.nextRecord();
             r.setID(-1);
             newTable.commit(r);
         }
@@ -753,7 +757,8 @@ public class ResourceTable {
     public String toString() {
         StringBuffer resourceDetails = new StringBuffer();
         int maxLength = 0;
-        for (Resource r : getResources()) {
+        for (IStorageIterator it = storage.iterate(); it.hasMore(); ) {
+            Resource r = (Resource)it.nextRecord();
             String line = "| " + r.getResourceId() + " | " + r.getVersion() +
                     " | " + getStatusString(r.getStatus()) + " |\n";
             resourceDetails.append(line);
@@ -838,7 +843,8 @@ public class ResourceTable {
 
     protected void cleanup() {
         parentCache.clear();
-        for (Resource r : getResources()) {
+        for (IStorageIterator it = storage.iterate(); it.hasMore(); ) {
+            Resource r = (Resource)it.nextRecord();
             r.getInstaller().cleanup();
         }
     }
@@ -856,7 +862,8 @@ public class ResourceTable {
         // TODO: Replace this with some sort of sorted priority queue.
         Vector<ResourceInstaller> lateInit = new Vector<ResourceInstaller>();
 
-        for (Resource r : this.getResources()) {
+        for (IStorageIterator it = storage.iterate(); it.hasMore(); ) {
+            Resource r = (Resource)it.nextRecord();
             ResourceInstaller i = r.getInstaller();
             if (i.requiresRuntimeInitialization()) {
                 if (i instanceof ProfileInstaller) {

--- a/backend/src/org/commcare/resources/model/ResourceTable.java
+++ b/backend/src/org/commcare/resources/model/ResourceTable.java
@@ -608,19 +608,15 @@ public class ResourceTable {
         // Upgrade elements should result in their counterpart in this table
         // being unstaged (which can be reverted).
 
-        Stack<Resource> resources = incoming.getResourceStack();
-        while (!resources.isEmpty()) {
-            Resource r = resources.pop();
-            Resource peer = this.getResourceWithId(r.getResourceId());
+        for (Resource r : incoming.getResources()) {
+            Resource peer = getResourceWithId(r.getResourceId());
             if (peer == null) {
                 // no corresponding resource in this table; use incoming
-                // XXX PLM: Why is this needed? Only ever called on global
-                // table, which is thrown away and replaced by incoming table
-                this.addResource(r, Resource.RESOURCE_STATUS_INSTALLED);
+                addResource(r, Resource.RESOURCE_STATUS_INSTALLED);
             } else {
                 if (r.isNewer(peer)) {
                     // Mark as being ready to transition
-                    this.commit(peer, Resource.RESOURCE_STATUS_INSTALL_TO_UNSTAGE);
+                    commit(peer, Resource.RESOURCE_STATUS_INSTALL_TO_UNSTAGE);
 
                     if (!peer.getInstaller().unstage(peer, Resource.RESOURCE_STATUS_UNSTAGED)) {
                         // TODO: revert this resource table!

--- a/backend/src/org/commcare/resources/model/ResourceTable.java
+++ b/backend/src/org/commcare/resources/model/ResourceTable.java
@@ -50,10 +50,13 @@ public class ResourceTable {
 
     private int numberOfLossyRetries = 3;
 
-    /**
-     * For Serialization Only!
-     */
     public ResourceTable() {
+    }
+
+    protected ResourceTable(IStorageUtilityIndexed storage,
+                            InstallerFactory factory) {
+        this.storage = storage;
+        this.factory = factory;
     }
 
     public boolean isEmpty() {
@@ -66,10 +69,7 @@ public class ResourceTable {
 
     public static ResourceTable RetrieveTable(IStorageUtilityIndexed storage,
                                               InstallerFactory factory) {
-        ResourceTable table = new ResourceTable();
-        table.storage = storage;
-        table.factory = factory;
-        return table;
+        return new ResourceTable(storage, factory);
     }
 
     public int getTableReadiness() {

--- a/backend/src/org/commcare/resources/model/ResourceTable.java
+++ b/backend/src/org/commcare/resources/model/ResourceTable.java
@@ -146,7 +146,8 @@ public class ResourceTable {
             addResourceInner(resource, status);
         } 
     }
-    private boolean resourceDoesntExist(Resource resource) {
+
+    protected boolean resourceDoesntExist(Resource resource) {
         return storage.getIDsForValue(Resource.META_INDEX_RESOURCE_ID, resource.getResourceId()).size() == 0;
     }
 
@@ -165,7 +166,7 @@ public class ResourceTable {
         }
 
         try {
-            storage.write(resource);
+            commit(resource);
         } catch (StorageFullException e) {
             e.printStackTrace();
         }
@@ -814,7 +815,7 @@ public class ResourceTable {
         storage.removeAll();
     }
 
-    private void cleanup() {
+    protected void cleanup() {
         for (Resource r : getResources()) {
             r.getInstaller().cleanup();
         }

--- a/backend/src/org/commcare/resources/model/ResourceTable.java
+++ b/backend/src/org/commcare/resources/model/ResourceTable.java
@@ -197,6 +197,18 @@ public class ResourceTable {
         }
     }
 
+    protected Resource getParentResource(Resource resource) {
+        String parentId = resource.getParentId();
+        if (parentId != null && !"".equals(parentId)) {
+            try {
+                return (Resource)storage.getRecordForValue(Resource.META_INDEX_RESOURCE_GUID, parentId);
+            } catch (NoSuchElementException nsee) {
+                return null;
+            }
+        }
+        return null;
+    }
+
     /**
      * Get the all the resources in this table's storage.
      */
@@ -865,7 +877,7 @@ public class ResourceTable {
         for (ResourceLocation location : r.getLocations()) {
             if (location.isRelative()) {
                 if (r.hasParent()) {
-                    Resource parent = t.getResourceWithGuid(r.getParentId());
+                    Resource parent = t.getParentResource(r);
                     if (parent != null) {
                         // Get local references for the parent resource's
                         // locations
@@ -902,11 +914,11 @@ public class ResourceTable {
         Vector<Reference> ret = new Vector<Reference>();
 
         if (r.hasParent()) {
-            Resource parent = t.getResourceWithGuid(r.getParentId());
+            Resource parent = t.getParentResource(r);
 
             // If the local table doesn't have the parent ref, try the master
             if (parent == null && m != null) {
-                parent = m.getResourceWithGuid(r.getParentId());
+                parent = m.getParentResource(r);
             }
 
             if (parent != null) {
@@ -944,12 +956,12 @@ public class ResourceTable {
             if (location.getAuthority() == type) {
                 if (location.isRelative()) {
                     if (r.hasParent()) {
-                        Resource parent = t.getResourceWithGuid(r.getParentId());
+                        Resource parent = t.getParentResource(r);
 
                         // If the local table doesn't have the parent ref, try
                         // the master
                         if (parent == null) {
-                            parent = m.getResourceWithGuid(r.getParentId());
+                            parent = m.getParentResource(r);
                         }
                         if (parent != null) {
                             // Get all local references for the parent

--- a/backend/src/org/commcare/resources/model/TableStateListener.java
+++ b/backend/src/org/commcare/resources/model/TableStateListener.java
@@ -4,9 +4,18 @@ package org.commcare.resources.model;
  * @author ctsims
  */
 public interface TableStateListener {
-    void resourceStateIncremented();
+    /**
+     * A basic resource was added to the table
+     */
+    void simpleResourceAdded();
 
-    void resourceStateUpdated(ResourceTable table);
+    /**
+     * A compound resource (i.e. profile or suite) was added to the table.
+     * There might now be more resources that need to be processed than before.
+     *
+     * @param table For calculating updated completed and total resource counts
+     */
+    void compoundResourceAdded(ResourceTable table);
 
     void incrementProgress(int complete, int total);
 }

--- a/backend/src/org/commcare/resources/model/TableStateListener.java
+++ b/backend/src/org/commcare/resources/model/TableStateListener.java
@@ -1,12 +1,11 @@
-/**
- *
- */
 package org.commcare.resources.model;
 
 /**
  * @author ctsims
  */
 public interface TableStateListener {
+    void resourceStateIncremented();
+
     void resourceStateUpdated(ResourceTable table);
 
     void incrementProgress(int complete, int total);

--- a/backend/src/org/commcare/resources/model/installers/ProfileInstaller.java
+++ b/backend/src/org/commcare/resources/model/installers/ProfileInstaller.java
@@ -120,12 +120,12 @@ public class ProfileInstaller extends CacheInstaller {
                 //If we're upgrading we need to come back and see if the statuses need to change
                 if (upgrade) {
                     getlocal().put(r.getRecordGuid(), p);
-                    table.commitProfileResource(r, Resource.RESOURCE_STATUS_LOCAL, p.getVersion());
+                    table.commitCompoundResource(r, Resource.RESOURCE_STATUS_LOCAL, p.getVersion());
                 } else {
                     p.initializeProperties(true);
                     installInternal(p);
                     //TODO: What if this fails? Maybe we should be throwing exceptions...
-                    table.commitProfileResource(r, Resource.RESOURCE_STATUS_INSTALLED, p.getVersion());
+                    table.commitCompoundResource(r, Resource.RESOURCE_STATUS_INSTALLED, p.getVersion());
                 }
 
                 return true;

--- a/backend/src/org/commcare/resources/model/installers/ProfileInstaller.java
+++ b/backend/src/org/commcare/resources/model/installers/ProfileInstaller.java
@@ -86,11 +86,11 @@ public class ProfileInstaller extends CacheInstaller {
             if (getlocal().containsKey(r.getRecordGuid()) && r.getStatus() == Resource.RESOURCE_STATUS_LOCAL) {
                 Profile local = getlocal().get(r.getRecordGuid());
                 installInternal(local);
-                table.commit(r, Resource.RESOURCE_STATUS_UPGRADE);
+                table.commitCompoundResource(r, Resource.RESOURCE_STATUS_UPGRADE);
                 localTable.remove(r.getRecordGuid());
 
                 for (Resource child : table.getResourcesForParent(r.getRecordGuid())) {
-                    table.commit(child, Resource.RESOURCE_STATUS_UNINITIALIZED);
+                    table.commitCompoundResource(child, Resource.RESOURCE_STATUS_UNINITIALIZED);
                 }
                 return true;
             }
@@ -120,12 +120,12 @@ public class ProfileInstaller extends CacheInstaller {
                 //If we're upgrading we need to come back and see if the statuses need to change
                 if (upgrade) {
                     getlocal().put(r.getRecordGuid(), p);
-                    table.commit(r, Resource.RESOURCE_STATUS_LOCAL, p.getVersion());
+                    table.commitProfileResource(r, Resource.RESOURCE_STATUS_LOCAL, p.getVersion());
                 } else {
                     p.initializeProperties(true);
                     installInternal(p);
                     //TODO: What if this fails? Maybe we should be throwing exceptions...
-                    table.commit(r, Resource.RESOURCE_STATUS_INSTALLED, p.getVersion());
+                    table.commitProfileResource(r, Resource.RESOURCE_STATUS_INSTALLED, p.getVersion());
                 }
 
                 return true;

--- a/backend/src/org/commcare/resources/model/installers/SuiteInstaller.java
+++ b/backend/src/org/commcare/resources/model/installers/SuiteInstaller.java
@@ -68,7 +68,7 @@ public class SuiteInstaller extends CacheInstaller<Suite> {
                 storage().write(s);
                 cacheLocation = s.getID();
 
-                table.commit(r, Resource.RESOURCE_STATUS_INSTALLED);
+                table.commitCompoundResource(r, Resource.RESOURCE_STATUS_INSTALLED);
 
                 //TODOD:
                 //Add a resource location for r for its cache location

--- a/util/src/org/commcare/util/CommCareConfigEngine.java
+++ b/util/src/org/commcare/util/CommCareConfigEngine.java
@@ -341,12 +341,12 @@ public class CommCareConfigEngine {
         int lastComplete = 0;
 
         @Override
-        public void resourceStateIncremented() {
+        public void simpleResourceAdded() {
 
         }
 
         @Override
-        public void resourceStateUpdated(ResourceTable table) {
+        public void compoundResourceAdded(ResourceTable table) {
 
         }
 

--- a/util/src/org/commcare/util/CommCareConfigEngine.java
+++ b/util/src/org/commcare/util/CommCareConfigEngine.java
@@ -341,6 +341,11 @@ public class CommCareConfigEngine {
         int lastComplete = 0;
 
         @Override
+        public void resourceStateIncremented() {
+
+        }
+
+        @Override
         public void resourceStateUpdated(ResourceTable table) {
 
         }


### PR DESCRIPTION
**Release Notes**: Install and update performance enhancements 

Speed-ups:
- From 12.5 minutes to 2.5 minutes for offline install of ICDS AWW app 
- From 8 mins to 1.5 for downloading an update
- From 12 mins to 2 for applying the downloaded update

Additional improvement: the install/update progress bar updates much more frequently 

Changes:
- Don't use intermediate vector when iterating over resources read from storage
- Don't recalculate table update/install progress every time a new resource is added. Only do it when a 'compound' resource is added. 'Compound' meaning a resource that points to other resources, such as a profile, suite, or media suite resource. 
- Store compound resources in a cache instead of loading them from storage. There should only ever be 3 of these, but they are accessed from storage pretty frequently right now.
- Lift storage look-ups out of loop bodies. Instead of looking up resources by ID from storage, load them all into an intermediate table that is passed around. I don't expect a table with 2k `Resource` objects to be an issue on older devices, but we should test that assumption.
- Unify `flagForDeletion` and `uninstall`, which both iterate over the same resource set, happen one right after the other, and can be lifted into the same loop, avoiding a pass of storage rights.

cross-request: https://github.com/dimagi/commcare-odk/pull/1309